### PR TITLE
Fix for issue #20: Overall distro test missing, part 2

### DIFF
--- a/ld/__init__.py
+++ b/ld/__init__.py
@@ -11,7 +11,8 @@ class LinuxDistribution(object):
                  os_release_file='',
                  distro_release_file=''):
         self.os_release_file = os_release_file or const._OS_RELEASE
-        self.distro_release_file = distro_release_file or ''
+        self.distro_release_file = distro_release_file or \
+            self._attempt_to_get_release_file()
         self._os_release_info = self.os_release_info()
         self._lsb_release_info = self.lsb_release_info() if include_lsb else {}
         self._dist_release_info = self.distro_release_info()
@@ -55,11 +56,9 @@ class LinuxDistribution(object):
 
         Note that any of these could be empty if not found.
         """
-        release_file = self.distro_release_file \
-            or self._attempt_to_get_release_file()
-        self.dist = self._get_dist_from_release_file(release_file)
-        if os.path.isfile(release_file):
-            with open(release_file, 'r') as f:
+        self.dist = self._get_dist_from_release_file(self.distro_release_file)
+        if os.path.isfile(self.distro_release_file):
+            with open(self.distro_release_file, 'r') as f:
                 # only parse the first line. For instance, on SuSE there are
                 # multiple lines. We don't want them...
                 return self._parse_release_file(f.readline())
@@ -187,7 +186,7 @@ class LinuxDistribution(object):
         files.sort()
         for f in files:
             if self._get_dist_from_release_file(f):
-                return f
+                return os.path.join(const._UNIXCONFDIR, f)
         return ''
 
     def id(self):

--- a/tests/test_ld.py
+++ b/tests/test_ld.py
@@ -3,11 +3,15 @@ import os
 import testtools
 
 import ld
+from ld import constants as const
 
 
 RESOURCES = os.path.join('tests', 'resources')
 DISTROS = os.path.join(RESOURCES, 'distros')
 SPECIAL = os.path.join(RESOURCES, 'special')
+
+RELATIVE_UNIXCONFDIR = const._UNIXCONFDIR.lstrip('/')
+RELATIVE_OS_RELEASE = const._OS_RELEASE.lstrip('/')
 
 
 class TestOSRelease(testtools.TestCase):
@@ -334,6 +338,208 @@ class TestDistRelease(testtools.TestCase):
         self.assertEqual(ldi.like(), '')
         self.assertEqual(ldi.codename(), '')
         self.assertEqual(ldi.base(), 'slackware')
+
+
+class TestOverall(testtools.TestCase):
+
+    def setUp(self):
+        super(TestOverall, self).setUp()
+
+    def _setup_for_distro(self, distro_root):
+        distro_bin = os.path.join(os.getcwd(), distro_root, 'bin')
+        # We don't want to pick up a possibly present lsb_release in the
+        # distro that runs this test, so we use a PATH with only one entry:
+        os.environ["PATH"] = distro_bin
+        const._UNIXCONFDIR = os.path.join(distro_root, RELATIVE_UNIXCONFDIR)
+        const._OS_RELEASE = os.path.join(distro_root, RELATIVE_OS_RELEASE)
+
+    def test_arch_release(self):
+        self._setup_for_distro(os.path.join(DISTROS, 'arch'))
+
+        ldi = ld.LinuxDistribution()
+
+        self.assertEqual(ldi.id(), 'arch')
+        self.assertEqual(ldi.name(), 'Arch Linux')
+        self.assertEqual(ldi.name(pretty=True), 'Arch Linux')
+        # Arch Linux has a continuous release concept:
+        self.assertEqual(ldi.version(), '')
+        self.assertEqual(ldi.version(pretty=True), '')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), '')
+        self.assertEqual(ldi.base(), 'arch')
+
+    def test_centos5_release(self):
+        self._setup_for_distro(os.path.join(DISTROS, 'centos5'))
+
+        ldi = ld.LinuxDistribution()
+
+        self.assertEqual(ldi.id(), 'centos')
+        self.assertEqual(ldi.name(), 'CentOS')
+        self.assertEqual(ldi.name(pretty=True), 'CentOS 5.11 (Final)')
+        self.assertEqual(ldi.version(), '5.11')
+        self.assertEqual(ldi.version(pretty=True), '5.11 (Final)')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), 'Final')
+        self.assertEqual(ldi.base(), 'rhel')
+        self.assertEqual(ldi.major_version(), '5')
+        self.assertEqual(ldi.minor_version(), '11')
+        self.assertEqual(ldi.build_number(), '')
+
+    def test_centos7_release(self):
+        self._setup_for_distro(os.path.join(DISTROS, 'centos7'))
+
+        ldi = ld.LinuxDistribution()
+
+        self.assertEqual(ldi.id(), 'centos')
+        self.assertEqual(ldi.name(), 'CentOS Linux')
+        self.assertEqual(ldi.name(pretty=True), 'CentOS Linux 7 (Core)')
+        # TODO: Fix issue that version() looses precision.
+        self.assertEqual(ldi.version(), '7')
+        self.assertEqual(ldi.version(pretty=True), '7 (Core)')
+        self.assertEqual(ldi.like(), 'rhel fedora')
+        self.assertEqual(ldi.codename(), 'Core')
+        self.assertEqual(ldi.base(), 'rhel')
+        self.assertEqual(ldi.major_version(), '7')
+        self.assertEqual(ldi.minor_version(), '')
+        self.assertEqual(ldi.build_number(), '')
+
+    def test_debian8_os_release(self):
+        self._setup_for_distro(os.path.join(DISTROS, 'debian8'))
+
+        ldi = ld.LinuxDistribution()
+
+        self.assertEqual(ldi.id(), 'debian')
+        self.assertEqual(ldi.name(), 'Debian GNU/Linux')
+        self.assertEqual(ldi.name(pretty=True), 'Debian GNU/Linux 8 (jessie)')
+        # TODO: Fix issue that version() looses precision.
+        self.assertEqual(ldi.version(), '8')
+        self.assertEqual(ldi.version(pretty=True), '8 (jessie)')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), 'jessie')
+        self.assertEqual(ldi.base(), 'debian')
+
+    def test_exherbo_release(self):
+        self._setup_for_distro(os.path.join(DISTROS, 'exherbo'))
+
+        ldi = ld.LinuxDistribution()
+
+        # TODO: This release file is currently empty and should be completed.
+        self.assertEqual(ldi.id(), 'exherbo')
+        self.assertEqual(ldi.name(), '')
+        self.assertEqual(ldi.name(pretty=True), '')
+        self.assertEqual(ldi.version(), '')
+        self.assertEqual(ldi.version(pretty=True), '')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), '')
+        self.assertEqual(ldi.base(), 'exherbo')
+
+    def test_fedora23_release(self):
+        self._setup_for_distro(os.path.join(DISTROS, 'fedora23'))
+
+        ldi = ld.LinuxDistribution()
+
+        self.assertEqual(ldi.id(), 'fedora')
+        self.assertEqual(ldi.name(), 'Fedora')
+        self.assertEqual(ldi.name(pretty=True), 'Fedora 23 (Twenty Three)')
+        self.assertEqual(ldi.version(), '23')
+        self.assertEqual(ldi.version(pretty=True), '23 (Twenty Three)')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), 'Twenty Three')
+        self.assertEqual(ldi.base(), 'fedora')
+
+    def test_opensuse42_release(self):
+        self._setup_for_distro(os.path.join(DISTROS, 'opensuse42'))
+
+        ldi = ld.LinuxDistribution()
+
+        self.assertEqual(ldi.id(), 'opensuse')
+        self.assertEqual(ldi.name(), 'openSUSE Leap')
+        self.assertEqual(ldi.name(pretty=True), 'openSUSE Leap 42.1 (x86_64)')
+        self.assertEqual(ldi.version(), '42.1')
+        self.assertEqual(ldi.version(pretty=True), '42.1')
+        self.assertEqual(ldi.like(), 'suse')
+        self.assertEqual(ldi.codename(), '')
+        self.assertEqual(ldi.base(), 'suse')
+        self.assertEqual(ldi.major_version(), '42')
+        self.assertEqual(ldi.minor_version(), '1')
+        self.assertEqual(ldi.build_number(), '')
+
+    def test_oracle7_release(self):
+        self._setup_for_distro(os.path.join(DISTROS, 'oracle7'))
+
+        ldi = ld.LinuxDistribution()
+
+        self.assertEqual(ldi.id(), 'oracle')
+        self.assertEqual(ldi.name(), 'Oracle Linux Server')
+        self.assertEqual(ldi.name(pretty=True), 'Oracle Linux Server 7.1')
+        self.assertEqual(ldi.version(), '7.1')
+        self.assertEqual(ldi.version(pretty=True), '7.1')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), '')
+        self.assertEqual(ldi.base(), 'rhel')
+
+    def test_rhel6_release(self):
+        self._setup_for_distro(os.path.join(DISTROS, 'rhel6'))
+
+        ldi = ld.LinuxDistribution()
+
+        self.assertEqual(ldi.id(), 'redhat')
+        self.assertEqual(ldi.name(), 'Red Hat Enterprise Linux Server')
+        self.assertEqual(
+            ldi.name(pretty=True),
+            'Red Hat Enterprise Linux Server 6.5 (Santiago)')
+        self.assertEqual(ldi.version(), '6.5')
+        self.assertEqual(ldi.version(pretty=True), '6.5 (Santiago)')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), 'Santiago')
+        self.assertEqual(ldi.base(), 'rhel')
+        self.assertEqual(ldi.version_parts(), ('6', '5', ''))
+
+    def test_rhel7_release(self):
+        self._setup_for_distro(os.path.join(DISTROS, 'rhel7'))
+
+        ldi = ld.LinuxDistribution()
+
+        # TODO: Resolve issue that the id() has changed compared to rhel6
+        self.assertEqual(ldi.id(), 'rhel')
+        self.assertEqual(ldi.name(), 'Red Hat Enterprise Linux Server')
+        self.assertEqual(
+            ldi.name(pretty=True),
+            'Red Hat Enterprise Linux Server 7.0 (Maipo)')
+        self.assertEqual(ldi.version(), '7.0')
+        self.assertEqual(ldi.version(pretty=True), '7.0 (Maipo)')
+        self.assertEqual(ldi.like(), 'fedora')
+        self.assertEqual(ldi.codename(), 'Maipo')
+        self.assertEqual(ldi.base(), 'fedora')
+        self.assertEqual(ldi.version_parts(), ('7', '0', ''))
+
+    def test_slackware14_release(self):
+        self._setup_for_distro(os.path.join(DISTROS, 'slackware14'))
+
+        ldi = ld.LinuxDistribution()
+
+        self.assertEqual(ldi.id(), 'slackware')
+        self.assertEqual(ldi.name(), 'Slackware')
+        self.assertEqual(ldi.name(pretty=True), 'Slackware 14.1')
+        self.assertEqual(ldi.version(), '14.1')
+        self.assertEqual(ldi.version(pretty=True), '14.1')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), '')
+        self.assertEqual(ldi.base(), 'slackware')
+
+    def test_ubuntu14_os_release(self):
+        self._setup_for_distro(os.path.join(DISTROS, 'ubuntu14'))
+
+        ldi = ld.LinuxDistribution()
+
+        self.assertEqual(ldi.id(), 'ubuntu')
+        self.assertEqual(ldi.name(), 'Ubuntu')
+        self.assertEqual(ldi.name(pretty=True), 'Ubuntu 14.04.3 LTS')
+        self.assertEqual(ldi.version(), '14.04')
+        self.assertEqual(ldi.version(pretty=True), '14.04 (Trusty Tahr)')
+        self.assertEqual(ldi.like(), 'debian')
+        self.assertEqual(ldi.codename(), 'Trusty Tahr')
+        self.assertEqual(ldi.base(), 'debian')
 
 
 class TestInfo(testtools.TestCase):


### PR DESCRIPTION
This merge request contains the implementation of the overall distro test, based on the new file structure under tests/resources.

In addition, it contains two fixes for issues that came up during the overall distro test:

1. `_attempt_to_get_release_file()` now returns the file path, instead of just the base file name. The prior code caused `distro_release_info()` to not find the file.

2. Not a real problem, but it helps when looking at an ldi object: Moved the determination of the distro file name using `_attempt_to_get_release_file()` into `__init__()`, so that the file that was found is stored in `self.distro_release_file`. In the prior code, the location of the file that was read was never stored anywhere in the ldi object, making debugging harder than needed. The `__init__()` method (which is called during module load because of the global `_ldi` object) already performs file access, so I thought one more test for a file does not make it much worse. But it is a review point: If we are concerned about file access at module load time, we should defer all file access to the first use of some data, not just this one.

In addition, fix26 (see issue #26) is the base for this merge request, so its commit is included here, because the overall tests depend on it.

Please review and merge.
