### PR TITLE
Final fix for issue #38: Test coverage is below 100%

### DIFF
--- a/ld/__init__.py
+++ b/ld/__init__.py
@@ -16,7 +16,7 @@ class LinuxDistribution(object):
         self._os_release_info = self._get_os_release_info()
         self._lsb_release_info = self._get_lsb_release_info() \
             if include_lsb else {}
-        self._dist_release_info = self._get_distro_release_info()
+        self._distro_release_info = self._get_distro_release_info()
 
     def __repr__(self):
         return \
@@ -25,12 +25,12 @@ class LinuxDistribution(object):
             "distro_release_file=%r, " \
             "_os_release_info=%r, " \
             "_lsb_release_info=%r, " \
-            "_dist_release_info=%r)" % \
+            "_distro_release_info=%r)" % \
             (self.os_release_file,
              self.distro_release_file,
              self._os_release_info,
              self._lsb_release_info,
-             self._dist_release_info)
+             self._distro_release_info)
 
     def os_release_info(self):
         """Returns a dictionary containing key value pairs
@@ -80,7 +80,8 @@ class LinuxDistribution(object):
         return self._distro_release_info
 
     def _get_distro_release_info(self):
-        self.dist = self._get_dist_from_release_file(self.distro_release_file)
+        self.dist = self._get_distro_from_release_file(
+            self.distro_release_file)
         if os.path.isfile(self.distro_release_file):
             with open(self.distro_release_file, 'r') as f:
                 # only parse the first line. For instance, on SuSE there are
@@ -88,8 +89,8 @@ class LinuxDistribution(object):
                 return self._parse_release_file(f.readline())
         return {}
 
-    def get_dist_release_attr(self, attribute):
-        return self._dist_release_info.get(attribute, '')
+    def get_distro_release_attr(self, attribute):
+        return self._distro_release_info.get(attribute, '')
 
     def get_os_release_attr(self, attribute):
         return self._os_release_info.get(attribute, '')
@@ -181,7 +182,7 @@ class LinuxDistribution(object):
         return props
 
     @staticmethod
-    def _get_dist_from_release_file(some_file):
+    def _get_distro_from_release_file(some_file):
         """Retrieves the distribution from a release file's name if the file
         provided is indeed a release file.
 
@@ -209,7 +210,7 @@ class LinuxDistribution(object):
         files = os.listdir(const._UNIXCONFDIR)
         files.sort()
         for f in files:
-            if self._get_dist_from_release_file(f):
+            if self._get_distro_from_release_file(f):
                 return os.path.join(const._UNIXCONFDIR, f)
         return ''
 
@@ -244,12 +245,12 @@ class LinuxDistribution(object):
         """
         name = self.get_os_release_attr('name') \
             or self.get_lsb_release_attr('distributor_id') \
-            or self.get_dist_release_attr('name')
+            or self.get_distro_release_attr('name')
         if pretty:
             name = self.get_os_release_attr('pretty_name') \
                 or self.get_lsb_release_attr('description')
             if not name:
-                name = self.get_dist_release_attr('name')
+                name = self.get_distro_release_attr('name')
                 version = self.version(pretty=True)
                 if version:
                     name = name + ' ' + version
@@ -263,7 +264,7 @@ class LinuxDistribution(object):
         """
         version = self.get_os_release_attr('version_id') \
             or self.get_lsb_release_attr('release') \
-            or self.get_dist_release_attr('version_id') \
+            or self.get_distro_release_attr('version_id') \
             or ''
         if pretty and version and self.codename():
             version = '{0} ({1})'.format(version, self.codename())
@@ -306,7 +307,7 @@ class LinuxDistribution(object):
         """
         return self.get_os_release_attr('codename') \
             or self.get_lsb_release_attr('codename') \
-            or self.get_dist_release_attr('codename') \
+            or self.get_distro_release_attr('codename') \
             or ''
 
     def base(self):

--- a/ld/__init__.py
+++ b/ld/__init__.py
@@ -13,9 +13,10 @@ class LinuxDistribution(object):
         self.os_release_file = os_release_file or const._OS_RELEASE
         self.distro_release_file = distro_release_file or \
             self._attempt_to_get_release_file()
-        self._os_release_info = self.os_release_info()
-        self._lsb_release_info = self.lsb_release_info() if include_lsb else {}
-        self._dist_release_info = self.distro_release_info()
+        self._os_release_info = self._get_os_release_info()
+        self._lsb_release_info = self._get_lsb_release_info() \
+            if include_lsb else {}
+        self._dist_release_info = self._get_distro_release_info()
 
     def __repr__(self):
         return \
@@ -38,6 +39,9 @@ class LinuxDistribution(object):
         See http://www.freedesktop.org/software/systemd/man/os-release.html
         as a reference.
         """
+        return self._os_release_info
+
+    def _get_os_release_info(self):
         if os.path.isfile(self.os_release_file):
             with open(self.os_release_file, 'r') as f:
                 return self._parse_key_value_files(f)
@@ -49,6 +53,9 @@ class LinuxDistribution(object):
         See http://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/lsbrelease.html  # NOQA
         as a reference.
         """
+        return self._lsb_release_info
+
+    def _get_lsb_release_info(self):
         stdout = subprocess.PIPE
         stderr = subprocess.PIPE
         r = subprocess.Popen(
@@ -70,6 +77,9 @@ class LinuxDistribution(object):
 
         Note that any of these could be empty if not found.
         """
+        return self._distro_release_info
+
+    def _get_distro_release_info(self):
         self.dist = self._get_dist_from_release_file(self.distro_release_file)
         if os.path.isfile(self.distro_release_file):
             with open(self.distro_release_file, 'r') as f:

--- a/ld/__init__.py
+++ b/ld/__init__.py
@@ -23,11 +23,13 @@ class LinuxDistribution(object):
             "LinuxDistribution(" \
             "os_release_file=%r, " \
             "distro_release_file=%r, " \
+            "dist=%r, " \
             "_os_release_info=%r, " \
             "_lsb_release_info=%r, " \
             "_distro_release_info=%r)" % \
             (self.os_release_file,
              self.distro_release_file,
+             getattr(self, "dist", None),
              self._os_release_info,
              self._lsb_release_info,
              self._distro_release_info)

--- a/tests/test_ld.py
+++ b/tests/test_ld.py
@@ -13,6 +13,7 @@ SPECIAL = os.path.join(RESOURCES, 'special')
 RELATIVE_UNIXCONFDIR = const._UNIXCONFDIR.lstrip('/')
 RELATIVE_OS_RELEASE = const._OS_RELEASE.lstrip('/')
 
+MODULE_LDI = ld._ldi
 
 class TestOSRelease(testtools.TestCase):
 
@@ -660,3 +661,68 @@ class TestInfo(testtools.TestCase):
         ldi = ld.LinuxDistribution(False, self.rhel7_os_release)
         i = ldi.linux_distribution(full_distribution_name=False)
         self.assertEqual(i, ('rhel', '7.0', 'Maipo'))
+
+class TestGlobal(testtools.TestCase):
+    """Test the global module-level functions, and default values of their
+    arguments."""
+
+    def test_global(self):
+        # Because the module-level functions use the module-global
+        # LinuxDistribution instance, it would influence the tested
+        # code too much if we mocked that in order to use the distro
+        # specific release files. Instead, we let the functions use
+        # the release files of the distro this test runs on, and
+        # compare the result of the global functions with the result
+        # of the methods on the global LinuxDistribution object.
+        self.assertEqual(ld.id(),
+            MODULE_LDI.id())
+        self.assertEqual(ld.name(),
+            MODULE_LDI.name(pretty=False))
+        self.assertEqual(ld.name(pretty=False),
+            MODULE_LDI.name())
+        self.assertEqual(ld.name(pretty=True),
+            MODULE_LDI.name(pretty=True))
+        self.assertEqual(ld.version(),
+            MODULE_LDI.version(pretty=False))
+        self.assertEqual(ld.version(pretty=False),
+            MODULE_LDI.version())
+        self.assertEqual(ld.version(pretty=True),
+            MODULE_LDI.version(pretty=True))
+        self.assertEqual(ld.major_version(),
+            MODULE_LDI.major_version())
+        self.assertEqual(ld.minor_version(),
+            MODULE_LDI.minor_version())
+        self.assertEqual(ld.build_number(),
+            MODULE_LDI.build_number())
+        self.assertEqual(ld.like(),
+            MODULE_LDI.like())
+        self.assertEqual(ld.codename(),
+            MODULE_LDI.codename())
+        self.assertEqual(ld.base(),
+            MODULE_LDI.base())
+        self.assertEqual(ld.linux_distribution(),
+            MODULE_LDI.linux_distribution(full_distribution_name=True))
+        self.assertEqual(ld.linux_distribution(full_distribution_name=True),
+            MODULE_LDI.linux_distribution())
+        self.assertEqual(ld.linux_distribution(full_distribution_name=False),
+            MODULE_LDI.linux_distribution(full_distribution_name=False))
+        self.assertEqual(ld.os_release_info(),
+            MODULE_LDI.os_release_info())
+        self.assertEqual(ld.lsb_release_info(),
+            MODULE_LDI.lsb_release_info())
+        self.assertEqual(ld.distro_release_info(),
+            MODULE_LDI.distro_release_info())
+        self.assertEqual(ld.info(),
+            MODULE_LDI.info())
+
+class TestRepr(testtools.TestCase):
+    """Test the __repr__() method."""
+
+    def test_repr(self):
+        # We test that the class name and the names of all instance attributes
+        # show up in the repr() string.
+        repr_str = repr(ld._ldi)
+        self.assertIn("LinuxDistribution", repr_str)
+        for attr in MODULE_LDI.__dict__.keys():
+            self.assertIn(attr+'=', repr_str)
+


### PR DESCRIPTION
This PR completes issue #38, and brings the test coverage to 100%.
The added testcases revealed that `__repr__()` did not include the `self.dist` instance attribute, which gets created in a method. This was fixed as well.
Please review and merge, if you agree.