### PR TITLE
Saving and restoring PATH in TestOverall

### DIFF
--- a/tests/test_ld.py
+++ b/tests/test_ld.py
@@ -407,6 +407,14 @@ class TestOverall(testtools.TestCase):
 
     def setUp(self):
         super(TestOverall, self).setUp()
+        # The environment stays the same across all testcases, so we
+        # save and restore the PATH env var in each test case that
+        # changes it:
+        self._saved_path = os.environ["PATH"]
+
+    def tearDown(self):
+        super(TestOverall, self).tearDown()
+        os.environ["PATH"] = self._saved_path
 
     def _setup_for_distro(self, distro_root):
         distro_bin = os.path.join(os.getcwd(), distro_root, 'bin')


### PR DESCRIPTION
The setup method for the overall distro test sets the PATH in the environment of the current Python process so that only the lsb_release command in the distro subtree is found. However, I verified that that PATH change remains in place across the whole test run.

This PR adds saving and restoring of the PATh value, in the setup and teardown routine of each testcase of the TestOverall class. This scopes the changed PATH to just the minimum, i.e. the testcases that need it.

Please review and merge, if you agree.