### PR TITLE
Fixes for issues #40 and #48

### DIFF
--- a/ld/__init__.py
+++ b/ld/__init__.py
@@ -11,8 +11,7 @@ class LinuxDistribution(object):
                  os_release_file='',
                  distro_release_file=''):
         self.os_release_file = os_release_file or const._OS_RELEASE
-        self.distro_release_file = distro_release_file or \
-            self._attempt_to_get_release_file()
+        self.distro_release_file = distro_release_file or ''
         self._os_release_info = self._get_os_release_info()
         self._lsb_release_info = self._get_lsb_release_info() \
             if include_lsb else {}
@@ -23,13 +22,11 @@ class LinuxDistribution(object):
             "LinuxDistribution(" \
             "os_release_file=%r, " \
             "distro_release_file=%r, " \
-            "dist=%r, " \
             "_os_release_info=%r, " \
             "_lsb_release_info=%r, " \
             "_distro_release_info=%r)" % \
             (self.os_release_file,
              self.distro_release_file,
-             getattr(self, "dist", None),
              self._os_release_info,
              self._lsb_release_info,
              self._distro_release_info)
@@ -69,27 +66,81 @@ class LinuxDistribution(object):
             r.read().decode('ascii').splitlines()) or {}
 
     def distro_release_info(self):
-        """Returns a dictionary containing parsed information
-        from the /etc/*-release file matching the relevant platform.
+        """Returns a dict with information from a distro release file.
 
-        The dict contains the following keys:
-        `name` - the name of the distribution.
-        `version` - the distribution's release version.
-        `codename` - the distribution's codename.
+        If `self.distro_release_file` is set (i.e. `distro_release_file` was
+        specified in the constructor), it is used as the path name of the
+        distro release file, and the returned dict will have those entries for
+        which data was found. Note that the returned dict may be empty.
 
-        Note that any of these could be empty if not found.
+        If `self.distro_release_file` is not set, a distro release file is
+        searched in the `/etc` directory that satisfies all of the following
+        conditions:
+        * Its file name matches the file name patterns `*-release` or
+          `*_release`.
+        * Its first line matches the pattern
+          `<name> [[[release] <release>] (<codename>)]`,
+          whereby components in square brackets are optional.
+        If such a file is found, the returned dict will have those entries for
+        which data was found, and `self.distro_release_file` is set to the
+        path name of the file. If such a file is not found, an empty dict is
+        returned.
+
+        The returned dict will have zero or more of the following entries:
+        * `id`: (string) Distro ID (e.g. `ubuntu`, `centos`, `redhat`), taken
+          from the first part of the file name.
+        * `name`: (string) Distro name (e.g. `Ubuntu`, `Debian GNU/Linux`),
+          as found in the first line of the file.
+        * `version_id`: (string) Distro version (e.g. `14.04 LTS`),
+          as found in the first line of the file.
+        * `codename`: (string) Distro code name (e.g. `Trusty Tahr`),
+          as found in the first line of the file.
+
+        TODO: In some cases the code name may be irrelevant (e.g.
+        `openSUSE 42.1 (x86_64)`). A possible solution for such code names
+        could be to not allow code names which have digits in them as there
+        might not be any.
         """
         return self._distro_release_info
 
     def _get_distro_release_info(self):
-        self.dist = self._get_distro_from_release_file(
-            self.distro_release_file)
-        if os.path.isfile(self.distro_release_file):
-            with open(self.distro_release_file, 'r') as f:
-                # only parse the first line. For instance, on SuSE there are
-                # multiple lines. We don't want them...
-                return self._parse_release_file(f.readline())
-        return {}
+        if self.distro_release_file:
+            # If it was specified, we use it and parse what we can, even if
+            # its file name or content does not match the expected pattern.
+            distro_info = self._parse_distro_release_file(
+                self.distro_release_file)
+            basefile = os.path.basename(self.distro_release_file)
+            # The file name pattern for user-specified distro release files
+            # is somewhat more tolerant (compared to when searching for the
+            # file), because we want to use what was specified as best as
+            # possible.
+            release_file_pattern = re.compile(r'(\w+)[-_](release|version)')
+            match = release_file_pattern.match(basefile)
+            if match:
+                distro_id = match.group(1)
+                # TODO: Normalize distro_id
+                distro_info['id'] = distro_id
+            return distro_info
+        else:
+            files = os.listdir(const._UNIXCONFDIR)
+            # We sort for repeatability in cases where there are multiple
+            # distro specific files; e.g. CentOS, Oracle, Enterprise all
+            # containing `redhat-release` on top of their own.
+            files.sort()
+            release_file_pattern = re.compile(r'(\w+)[-_]release')
+            for basefile in files:
+                match = release_file_pattern.match(basefile)
+                if match:
+                    distro_id = match.group(1)
+                    # TODO: Normalize distro_id
+                    filepath = os.path.join(const._UNIXCONFDIR, basefile)
+                    distro_info = self._parse_distro_release_file(filepath)
+                    if 'name' in distro_info:
+                        # The name is always present if the pattern matches
+                        self.distro_release_file = filepath
+                        distro_info['id'] = distro_id
+                        return distro_info
+            return {}
 
     def get_distro_release_attr(self, attribute):
         return self._distro_release_info.get(attribute, '')
@@ -152,69 +203,27 @@ class LinuxDistribution(object):
             props.update({k.replace(' ', '_').lower(): v.strip()})
         return props
 
+    def _parse_distro_release_file(self, filepath):
+        if os.path.isfile(filepath):
+            with open(filepath, 'r') as fp:
+                # Only parse the first line. For instance, on SuSE there
+                # are multiple lines. We don't want them...
+                return self._parse_distro_release_content(fp.readline())
+        return {}
+
     @staticmethod
-    def _parse_release_file(content):
-        """Parses a release file.
-
-        This will create a dict with the name, version and codename
-        extracted from a release file.
-
-        In some cases the codename may be irrelevant.
-        (e.g. openSUSE 42.1 (x86_64)).
-
-        Under consideration:
-        A possible solution could be to not allow codenames which have
-        digits in them as there might not be any.
-        """
+    def _parse_distro_release_content(content):
         _release_version = re.compile(
             r'(?:[^)]*\)(.*)\()? *([\d.+\-a-z]*\d) *(?:esaeler *)?(.+)')
         m = _release_version.match(content.strip()[::-1])
-        if not m:
-            name = version = codename = ''
-            # TODO: Maybe improve this way of handling non-matching
-        else:
-            name = m.group(3)[::-1]   # regexp ensures it is non-None
-            version = m.group(2)[::-1]   # regexp ensures it is non-None
-            codename = (m.group(1) or '')[::-1]   # may be None
-        props = {
-            'name': name,
-            'version_id': version,
-            'codename': codename
-        }
-        return props
-
-    @staticmethod
-    def _get_distro_from_release_file(some_file):
-        """Retrieves the distribution from a release file's name if the file
-        provided is indeed a release file.
-
-        This will only return a distribution if it's supported.
-        """
-        some_file = os.path.basename(some_file)
-        release_file_pattern = re.compile(r'(\w+)([-_])(release|version)')
-        match = release_file_pattern.match(some_file)
-        if match:
-            # release files are like: redhat-release or slackware_version.
-            # the first part is always assumed to be the dist name.
-            dist = match.groups()[0]
-            if dist in const._DIST_TO_BASE.keys():
-                return dist
-
-    def _attempt_to_get_release_file(self):
-        """Looks for release files in the system.
-
-        If a file is found that matches one of the supported distros,
-        this will return it.
-        """
-        # we sort for very specific cases in which
-        # there are two distro specific files e.g. CentOS, Oracle, Enterprise
-        # all also containing `redhat-release` on top of their own.
-        files = os.listdir(const._UNIXCONFDIR)
-        files.sort()
-        for f in files:
-            if self._get_distro_from_release_file(f):
-                return os.path.join(const._UNIXCONFDIR, f)
-        return ''
+        distro_info = {}
+        if m:
+            distro_info['name'] = m.group(3)[::-1]   # regexp ensures non-None
+            if m.group(2):
+                distro_info['version_id'] = m.group(2)[::-1]
+            if m.group(1):
+                distro_info['codename'] = m.group(1)[::-1]
+        return distro_info
 
     def id(self):
         """Returns the id for the distribution.
@@ -230,7 +239,7 @@ class LinuxDistribution(object):
         """
         return self.get_os_release_attr('id') \
             or self.get_lsb_release_attr('distributor_id').lower() \
-            or self.dist \
+            or self.get_distro_release_attr('id') \
             or ''
 
     def name(self, pretty=False):

--- a/ld/constants.py
+++ b/ld/constants.py
@@ -1,5 +1,5 @@
 _UNIXCONFDIR = '/etc'
-_OS_RELEASE = '/etc/os-release'
+_OS_RELEASE_BASENAME = 'os-release'
 
 _DIST_TO_BASE = {
     'debian': 'debian',

--- a/tests/resources/distros/ubuntu14/etc/debian_version
+++ b/tests/resources/distros/ubuntu14/etc/debian_version
@@ -1,0 +1,1 @@
+jessie/sid

--- a/tests/resources/testdistros/unknowndistro/etc/unknowndistro-release
+++ b/tests/resources/testdistros/unknowndistro/etc/unknowndistro-release
@@ -1,0 +1,1 @@
+Unknown Distro release 1.0 (Unknown Codename)

--- a/tests/test_ld.py
+++ b/tests/test_ld.py
@@ -12,7 +12,6 @@ TESTDISTROS = os.path.join(RESOURCES, 'testdistros')
 SPECIAL = os.path.join(RESOURCES, 'special')
 
 RELATIVE_UNIXCONFDIR = const._UNIXCONFDIR.lstrip('/')
-RELATIVE_OS_RELEASE = const._OS_RELEASE.lstrip('/')
 
 MODULE_LDI = ld._ldi
 
@@ -404,17 +403,19 @@ class TestDistRelease(testtools.TestCase):
         self.assertEqual(ldi.base(), 'slackware')
 
 
-class TestOverall(testtools.TestCase):
+class DistroTestCase(testtools.TestCase):
+    """A base class for any testcase classes that test the distributions
+    represented in the `DISTROS` subtree."""
 
     def setUp(self):
-        super(TestOverall, self).setUp()
+        super(DistroTestCase, self).setUp()
         # The environment stays the same across all testcases, so we
         # save and restore the PATH env var in each test case that
         # changes it:
         self._saved_path = os.environ["PATH"]
 
     def tearDown(self):
-        super(TestOverall, self).tearDown()
+        super(DistroTestCase, self).tearDown()
         os.environ["PATH"] = self._saved_path
 
     def _setup_for_distro(self, distro_root):
@@ -423,7 +424,20 @@ class TestOverall(testtools.TestCase):
         # distro that runs this test, so we use a PATH with only one entry:
         os.environ["PATH"] = distro_bin
         const._UNIXCONFDIR = os.path.join(distro_root, RELATIVE_UNIXCONFDIR)
-        const._OS_RELEASE = os.path.join(distro_root, RELATIVE_OS_RELEASE)
+
+
+class TestOverall(DistroTestCase):
+    """Test a LinuxDistribution object created with default arguments.
+
+    The direct accessor functions on that object are tested (e.g. `id()`); they
+    implement the precedence between the different sources of information.
+
+    In addition, because the distro release file is searched when not
+    specified, the information resulting from the distro release file is also
+    tested. The LSB and os-release sources are not tested again, because their
+    test is already done in TestLSBRelease and TestOSRelease, and their
+    algorithm does not depend on whether or not the file is specified.
+    """
 
     def test_arch_release(self):
         self._setup_for_distro(os.path.join(DISTROS, 'arch'))
@@ -439,6 +453,12 @@ class TestOverall(testtools.TestCase):
         self.assertEqual(ldi.like(), '')
         self.assertEqual(ldi.codename(), '')
         self.assertEqual(ldi.base(), 'arch')
+
+        # Test the info from the searched distro release file
+        # Does not have one; The empty /etc/arch-release file is not
+        # considered a valid distro release file:
+        self.assertEqual(ldi.distro_release_file, '')
+        self.assertEqual(len(ldi.distro_release_info()), 0)
 
     def test_centos5_release(self):
         self._setup_for_distro(os.path.join(DISTROS, 'centos5'))
@@ -456,6 +476,15 @@ class TestOverall(testtools.TestCase):
         self.assertEqual(ldi.major_version(), '5')
         self.assertEqual(ldi.minor_version(), '11')
         self.assertEqual(ldi.build_number(), '')
+
+        # Test the info from the searched distro release file
+        self.assertEqual(os.path.basename(ldi.distro_release_file),
+                         'centos-release')
+        distro_info = ldi.distro_release_info()
+        self.assertEqual(distro_info['id'], 'centos')
+        self.assertEqual(distro_info['name'], 'CentOS')
+        self.assertEqual(distro_info['version_id'], '5.11')
+        self.assertEqual(distro_info['codename'], 'Final')
 
     def test_centos7_release(self):
         self._setup_for_distro(os.path.join(DISTROS, 'centos7'))
@@ -475,6 +504,15 @@ class TestOverall(testtools.TestCase):
         self.assertEqual(ldi.minor_version(), '')
         self.assertEqual(ldi.build_number(), '')
 
+        # Test the info from the searched distro release file
+        self.assertEqual(os.path.basename(ldi.distro_release_file),
+                         'centos-release')
+        distro_info = ldi.distro_release_info()
+        self.assertEqual(distro_info['id'], 'centos')
+        self.assertEqual(distro_info['name'], 'CentOS Linux')
+        self.assertEqual(distro_info['version_id'], '7.1.1503')
+        self.assertEqual(distro_info['codename'], 'Core')
+
     def test_debian8_release(self):
         self._setup_for_distro(os.path.join(DISTROS, 'debian8'))
 
@@ -489,6 +527,11 @@ class TestOverall(testtools.TestCase):
         self.assertEqual(ldi.like(), '')
         self.assertEqual(ldi.codename(), 'jessie')
         self.assertEqual(ldi.base(), 'debian')
+
+        # Test the info from the searched distro release file
+        # Does not have one:
+        self.assertEqual(ldi.distro_release_file, '')
+        self.assertEqual(len(ldi.distro_release_info()), 0)
 
     def test_exherbo_release(self):
         self._setup_for_distro(os.path.join(DISTROS, 'exherbo'))
@@ -505,6 +548,9 @@ class TestOverall(testtools.TestCase):
         self.assertEqual(ldi.codename(), '')
         self.assertEqual(ldi.base(), '')
 
+        # Test the info from the searched distro release file
+        # TODO: Add tests for searched Exherbo distro release file
+
     def test_fedora23_release(self):
         self._setup_for_distro(os.path.join(DISTROS, 'fedora23'))
 
@@ -518,6 +564,15 @@ class TestOverall(testtools.TestCase):
         self.assertEqual(ldi.like(), '')
         self.assertEqual(ldi.codename(), 'Twenty Three')
         self.assertEqual(ldi.base(), 'fedora')
+
+        # Test the info from the searched distro release file
+        self.assertEqual(os.path.basename(ldi.distro_release_file),
+                         'fedora-release')
+        distro_info = ldi.distro_release_info()
+        self.assertEqual(distro_info['id'], 'fedora')
+        self.assertEqual(distro_info['name'], 'Fedora')
+        self.assertEqual(distro_info['version_id'], '23')
+        self.assertEqual(distro_info['codename'], 'Twenty Three')
 
     def test_mageia5_release(self):
         self._setup_for_distro(os.path.join(DISTROS, 'mageia5'))
@@ -533,6 +588,15 @@ class TestOverall(testtools.TestCase):
         # TODO: Codename differs between distro release file and lsb_release.
         self.assertEqual(ldi.codename(), 'thornicroft')
         self.assertEqual(ldi.base(), 'mandrake')
+
+        # Test the info from the searched distro release file
+        self.assertEqual(os.path.basename(ldi.distro_release_file),
+                         'mageia-release')
+        distro_info = ldi.distro_release_info()
+        self.assertEqual(distro_info['id'], 'mageia')
+        self.assertEqual(distro_info['name'], 'Mageia')
+        self.assertEqual(distro_info['version_id'], '5')
+        self.assertEqual(distro_info['codename'], 'Official')
 
     def test_opensuse42_release(self):
         self._setup_for_distro(os.path.join(DISTROS, 'opensuse42'))
@@ -551,6 +615,15 @@ class TestOverall(testtools.TestCase):
         self.assertEqual(ldi.minor_version(), '1')
         self.assertEqual(ldi.build_number(), '')
 
+        # Test the info from the searched distro release file
+        self.assertEqual(os.path.basename(ldi.distro_release_file),
+                         'SuSE-release')
+        distro_info = ldi.distro_release_info()
+        self.assertEqual(distro_info['id'], 'SuSE')
+        self.assertEqual(distro_info['name'], 'openSUSE')
+        self.assertEqual(distro_info['version_id'], '42.1')
+        self.assertEqual(distro_info['codename'], 'x86_64')
+
     def test_oracle7_release(self):
         self._setup_for_distro(os.path.join(DISTROS, 'oracle7'))
 
@@ -564,6 +637,15 @@ class TestOverall(testtools.TestCase):
         self.assertEqual(ldi.like(), '')
         self.assertEqual(ldi.codename(), '')
         self.assertEqual(ldi.base(), 'rhel')
+
+        # Test the info from the searched distro release file
+        self.assertEqual(os.path.basename(ldi.distro_release_file),
+                         'oracle-release')
+        distro_info = ldi.distro_release_info()
+        self.assertEqual(distro_info['id'], 'oracle')
+        self.assertEqual(distro_info['name'], 'Oracle Linux Server')
+        self.assertEqual(distro_info['version_id'], '7.1')
+        self.assertTrue('codename' not in distro_info)
 
     def test_rhel6_release(self):
         self._setup_for_distro(os.path.join(DISTROS, 'rhel6'))
@@ -581,6 +663,16 @@ class TestOverall(testtools.TestCase):
         self.assertEqual(ldi.codename(), 'Santiago')
         self.assertEqual(ldi.base(), 'rhel')
         self.assertEqual(ldi.version_parts(), ('6', '5', ''))
+
+        # Test the info from the searched distro release file
+        self.assertEqual(os.path.basename(ldi.distro_release_file),
+                         'redhat-release')
+        distro_info = ldi.distro_release_info()
+        self.assertEqual(distro_info['id'], 'redhat')
+        self.assertEqual(distro_info['name'],
+                         'Red Hat Enterprise Linux Server')
+        self.assertEqual(distro_info['version_id'], '6.5')
+        self.assertEqual(distro_info['codename'], 'Santiago')
 
     def test_rhel7_release(self):
         self._setup_for_distro(os.path.join(DISTROS, 'rhel7'))
@@ -600,6 +692,16 @@ class TestOverall(testtools.TestCase):
         self.assertEqual(ldi.base(), 'fedora')
         self.assertEqual(ldi.version_parts(), ('7', '0', ''))
 
+        # Test the info from the searched distro release file
+        self.assertEqual(os.path.basename(ldi.distro_release_file),
+                         'redhat-release')
+        distro_info = ldi.distro_release_info()
+        self.assertEqual(distro_info['id'], 'redhat')
+        self.assertEqual(distro_info['name'],
+                         'Red Hat Enterprise Linux Server')
+        self.assertEqual(distro_info['version_id'], '7.0')
+        self.assertEqual(distro_info['codename'], 'Maipo')
+
     def test_slackware14_release(self):
         self._setup_for_distro(os.path.join(DISTROS, 'slackware14'))
 
@@ -614,6 +716,15 @@ class TestOverall(testtools.TestCase):
         self.assertEqual(ldi.codename(), '')
         self.assertEqual(ldi.base(), 'slackware')
 
+        # Test the info from the searched distro release file
+        self.assertEqual(os.path.basename(ldi.distro_release_file),
+                         'slackware-version')
+        distro_info = ldi.distro_release_info()
+        self.assertEqual(distro_info['id'], 'slackware')
+        self.assertEqual(distro_info['name'], 'Slackware')
+        self.assertEqual(distro_info['version_id'], '14.1')
+        self.assertTrue('codename' not in distro_info)
+
     def test_ubuntu14_release(self):
         self._setup_for_distro(os.path.join(DISTROS, 'ubuntu14'))
 
@@ -627,6 +738,12 @@ class TestOverall(testtools.TestCase):
         self.assertEqual(ldi.like(), 'debian')
         self.assertEqual(ldi.codename(), 'Trusty Tahr')
         self.assertEqual(ldi.base(), 'debian')
+
+        # Test the info from the searched distro release file
+        # Does not have one; /etc/debian_version is not considered a distro
+        # release file:
+        self.assertEqual(ldi.distro_release_file, '')
+        self.assertEqual(len(ldi.distro_release_info()), 0)
 
     def test_unknowndistro_release(self):
         self._setup_for_distro(os.path.join(TESTDISTROS, 'unknowndistro'))
@@ -643,6 +760,51 @@ class TestOverall(testtools.TestCase):
         self.assertEqual(ldi.codename(), 'Unknown Codename')
         self.assertEqual(ldi.base(), '')
 
+
+class TestGetAttr(DistroTestCase):
+    """Test the consistency between the results of
+    `get_{source}_release_attr()` and `{source}_release_info()` for all
+    distros in `DISTROS`."""
+
+    def test_os_release_attr(self):
+        distros = os.listdir(DISTROS)
+        for distro in distros:
+            self._setup_for_distro(os.path.join(DISTROS, distro))
+
+            ldi = ld.LinuxDistribution()
+
+            info = ldi.os_release_info()
+            for key in info.keys():
+                self.assertEqual(info[key],
+                                 ldi.get_os_release_attr(key),
+                                 "distro: %s, key: %s" % (distro, key))
+            
+    def test_lsb_release_attr(self):
+        distros = os.listdir(DISTROS)
+        for distro in distros:
+            self._setup_for_distro(os.path.join(DISTROS, distro))
+
+            ldi = ld.LinuxDistribution()
+
+            info = ldi.lsb_release_info()
+            for key in info.keys():
+                self.assertEqual(info[key],
+                                 ldi.get_lsb_release_attr(key),
+                                 "distro: %s, key: %s" % (distro, key))
+            
+    def test_distro_release_attr(self):
+        distros = os.listdir(DISTROS)
+        for distro in distros:
+            self._setup_for_distro(os.path.join(DISTROS, distro))
+
+            ldi = ld.LinuxDistribution()
+
+            info = ldi.distro_release_info()
+            for key in info.keys():
+                self.assertEqual(info[key],
+                                 ldi.get_distro_release_attr(key),
+                                 "distro: %s, key: %s" % (distro, key))
+            
 
 class TestInfo(testtools.TestCase):
 
@@ -685,6 +847,7 @@ class TestInfo(testtools.TestCase):
         ldi = ld.LinuxDistribution(False, self.rhel7_os_release)
         i = ldi.linux_distribution(full_distribution_name=False)
         self.assertEqual(i, ('rhel', '7.0', 'Maipo'))
+
 
 class TestGlobal(testtools.TestCase):
     """Test the global module-level functions, and default values of their
@@ -738,6 +901,7 @@ class TestGlobal(testtools.TestCase):
             MODULE_LDI.distro_release_info())
         self.assertEqual(ld.info(),
             MODULE_LDI.info())
+
 
 class TestRepr(testtools.TestCase):
     """Test the __repr__() method."""

--- a/tests/test_ld.py
+++ b/tests/test_ld.py
@@ -8,6 +8,7 @@ from ld import constants as const
 
 RESOURCES = os.path.join('tests', 'resources')
 DISTROS = os.path.join(RESOURCES, 'distros')
+TESTDISTROS = os.path.join(RESOURCES, 'testdistros')
 SPECIAL = os.path.join(RESOURCES, 'special')
 
 RELATIVE_UNIXCONFDIR = const._UNIXCONFDIR.lstrip('/')
@@ -251,14 +252,14 @@ class TestDistRelease(testtools.TestCase):
 
         ldi = ld.LinuxDistribution(False, 'non', distro_release)
 
-        self.assertEqual(ldi.id(), '')
+        self.assertEqual(ldi.id(), 'SuSE')
         self.assertEqual(ldi.name(), 'openSUSE')
         self.assertEqual(ldi.name(pretty=True), 'openSUSE 42.1 (x86_64)')
         self.assertEqual(ldi.version(), '42.1')
         self.assertEqual(ldi.version(pretty=True), '42.1 (x86_64)')
         self.assertEqual(ldi.like(), '')
         self.assertEqual(ldi.codename(), 'x86_64')
-        self.assertEqual(ldi.base(), '')
+        self.assertEqual(ldi.base(), 'suse')
         self.assertEqual(ldi.major_version(), '42')
         self.assertEqual(ldi.minor_version(), '1')
         self.assertEqual(ldi.build_number(), '')
@@ -333,7 +334,7 @@ class TestDistRelease(testtools.TestCase):
 
         ldi = ld.LinuxDistribution(False, 'non', distro_release)
 
-        self.assertEqual(ldi.id(), '')
+        self.assertEqual(ldi.id(), 'empty')
         self.assertEqual(ldi.name(), '')
         self.assertEqual(ldi.name(pretty=True), '')
         self.assertEqual(ldi.version(), '')
@@ -495,14 +496,14 @@ class TestOverall(testtools.TestCase):
         ldi = ld.LinuxDistribution()
 
         # TODO: This release file is currently empty and should be completed.
-        self.assertEqual(ldi.id(), 'exherbo')
+        self.assertEqual(ldi.id(), '')
         self.assertEqual(ldi.name(), '')
         self.assertEqual(ldi.name(pretty=True), '')
         self.assertEqual(ldi.version(), '')
         self.assertEqual(ldi.version(pretty=True), '')
         self.assertEqual(ldi.like(), '')
         self.assertEqual(ldi.codename(), '')
-        self.assertEqual(ldi.base(), 'exherbo')
+        self.assertEqual(ldi.base(), '')
 
     def test_fedora23_release(self):
         self._setup_for_distro(os.path.join(DISTROS, 'fedora23'))
@@ -542,9 +543,9 @@ class TestOverall(testtools.TestCase):
         self.assertEqual(ldi.name(), 'openSUSE Leap')
         self.assertEqual(ldi.name(pretty=True), 'openSUSE Leap 42.1 (x86_64)')
         self.assertEqual(ldi.version(), '42.1')
-        self.assertEqual(ldi.version(pretty=True), '42.1')
+        self.assertEqual(ldi.version(pretty=True), '42.1 (x86_64)')
         self.assertEqual(ldi.like(), 'suse')
-        self.assertEqual(ldi.codename(), '')
+        self.assertEqual(ldi.codename(), 'x86_64')
         self.assertEqual(ldi.base(), 'suse')
         self.assertEqual(ldi.major_version(), '42')
         self.assertEqual(ldi.minor_version(), '1')
@@ -626,6 +627,21 @@ class TestOverall(testtools.TestCase):
         self.assertEqual(ldi.like(), 'debian')
         self.assertEqual(ldi.codename(), 'Trusty Tahr')
         self.assertEqual(ldi.base(), 'debian')
+
+    def test_unknowndistro_os_release(self):
+        self._setup_for_distro(os.path.join(TESTDISTROS, 'unknowndistro'))
+
+        ldi = ld.LinuxDistribution()
+
+        self.assertEqual(ldi.id(), 'unknowndistro')
+        self.assertEqual(ldi.name(), 'Unknown Distro')
+        self.assertEqual(ldi.name(pretty=True),
+                         'Unknown Distro 1.0 (Unknown Codename)')
+        self.assertEqual(ldi.version(), '1.0')
+        self.assertEqual(ldi.version(pretty=True), '1.0 (Unknown Codename)')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), 'Unknown Codename')
+        self.assertEqual(ldi.base(), '')
 
 
 class TestInfo(testtools.TestCase):

--- a/tests/test_ld.py
+++ b/tests/test_ld.py
@@ -21,6 +21,90 @@ class TestOSRelease(testtools.TestCase):
     def setUp(self):
         super(TestOSRelease, self).setUp()
 
+    def test_arch_os_release(self):
+        os_release = os.path.join(DISTROS, 'arch', 'etc', 'os-release')
+
+        ldi = ld.LinuxDistribution(False, os_release, 'non')
+
+        self.assertEqual(ldi.id(), 'arch')
+        self.assertEqual(ldi.name(), 'Arch Linux')
+        self.assertEqual(ldi.name(pretty=True), 'Arch Linux')
+        self.assertEqual(ldi.version(), '')
+        self.assertEqual(ldi.version(pretty=True), '')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), '')
+        self.assertEqual(ldi.base(), 'arch')
+
+    def test_centos7_os_release(self):
+        os_release = os.path.join(DISTROS, 'centos7', 'etc', 'os-release')
+
+        ldi = ld.LinuxDistribution(False, os_release, 'non')
+
+        self.assertEqual(ldi.id(), 'centos')
+        self.assertEqual(ldi.name(), 'CentOS Linux')
+        self.assertEqual(ldi.name(pretty=True), 'CentOS Linux 7 (Core)')
+        self.assertEqual(ldi.version(), '7')
+        self.assertEqual(ldi.version(pretty=True), '7 (Core)')
+        self.assertEqual(ldi.like(), 'rhel fedora')
+        self.assertEqual(ldi.codename(), 'Core')
+        self.assertEqual(ldi.base(), 'rhel')
+
+    def test_debian8_os_release(self):
+        os_release = os.path.join(DISTROS, 'debian8', 'etc', 'os-release')
+
+        ldi = ld.LinuxDistribution(False, os_release, 'non')
+
+        self.assertEqual(ldi.id(), 'debian')
+        self.assertEqual(ldi.name(), 'Debian GNU/Linux')
+        self.assertEqual(ldi.name(pretty=True), 'Debian GNU/Linux 8 (jessie)')
+        self.assertEqual(ldi.version(), '8')
+        self.assertEqual(ldi.version(pretty=True), '8 (jessie)')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), 'jessie')
+        self.assertEqual(ldi.base(), 'debian')
+
+    def test_fedora23_os_release(self):
+        os_release = os.path.join(DISTROS, 'fedora23', 'etc', 'os-release')
+
+        ldi = ld.LinuxDistribution(False, os_release, 'non')
+
+        self.assertEqual(ldi.id(), 'fedora')
+        self.assertEqual(ldi.name(), 'Fedora')
+        self.assertEqual(ldi.name(pretty=True), 'Fedora 23 (Twenty Three)')
+        self.assertEqual(ldi.version(), '23')
+        self.assertEqual(ldi.version(pretty=True), '23 (Twenty Three)')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), 'Twenty Three')
+        self.assertEqual(ldi.base(), 'fedora')
+
+    def test_mageia5_os_release(self):
+        os_release = os.path.join(DISTROS, 'mageia5', 'etc', 'os-release')
+
+        ldi = ld.LinuxDistribution(False, os_release, 'non')
+
+        self.assertEqual(ldi.id(), 'mageia')
+        self.assertEqual(ldi.name(), 'Mageia')
+        self.assertEqual(ldi.name(pretty=True), 'Mageia 5')
+        self.assertEqual(ldi.version(), '5')
+        self.assertEqual(ldi.version(pretty=True), '5')
+        self.assertEqual(ldi.like(), 'mandriva fedora')
+        self.assertEqual(ldi.codename(), '')
+        self.assertEqual(ldi.base(), 'mandrake')
+
+    def test_opensuse42_os_release(self):
+        os_release = os.path.join(DISTROS, 'opensuse42', 'etc', 'os-release')
+
+        ldi = ld.LinuxDistribution(False, os_release, 'non')
+
+        self.assertEqual(ldi.id(), 'opensuse')
+        self.assertEqual(ldi.name(), 'openSUSE Leap')
+        self.assertEqual(ldi.name(pretty=True), 'openSUSE Leap 42.1 (x86_64)')
+        self.assertEqual(ldi.version(), '42.1')
+        self.assertEqual(ldi.version(pretty=True), '42.1')
+        self.assertEqual(ldi.like(), 'suse')
+        self.assertEqual(ldi.codename(), '')
+        self.assertEqual(ldi.base(), 'suse')
+
     def test_rhel7_os_release(self):
         os_release = os.path.join(DISTROS, 'rhel7', 'etc', 'os-release')
 
@@ -37,47 +121,19 @@ class TestOSRelease(testtools.TestCase):
         self.assertEqual(ldi.codename(), 'Maipo')
         self.assertEqual(ldi.base(), 'fedora')
 
-    def test_centos7_os_release(self):
-        os_release = os.path.join(DISTROS, 'centos7', 'etc', 'os-release')
+    def test_slackware14_os_release(self):
+        os_release = os.path.join(DISTROS, 'slackware14', 'etc', 'os-release')
 
         ldi = ld.LinuxDistribution(False, os_release, 'non')
 
-        self.assertEqual(ldi.id(), 'centos')
-        self.assertEqual(ldi.name(), 'CentOS Linux')
-        self.assertEqual(ldi.name(pretty=True), 'CentOS Linux 7 (Core)')
-        self.assertEqual(ldi.version(), '7')
-        self.assertEqual(ldi.version(pretty=True), '7 (Core)')
-        self.assertEqual(ldi.like(), 'rhel fedora')
-        self.assertEqual(ldi.codename(), 'Core')
-        self.assertEqual(ldi.base(), 'rhel')
-
-    def test_opensuse42_os_release(self):
-        os_release = os.path.join(DISTROS, 'opensuse42', 'etc', 'os-release')
-
-        ldi = ld.LinuxDistribution(False, os_release, 'non')
-
-        self.assertEqual(ldi.id(), 'opensuse')
-        self.assertEqual(ldi.name(), 'openSUSE Leap')
-        self.assertEqual(ldi.name(pretty=True), 'openSUSE Leap 42.1 (x86_64)')
-        self.assertEqual(ldi.version(), '42.1')
-        self.assertEqual(ldi.version(pretty=True), '42.1')
-        self.assertEqual(ldi.like(), 'suse')
-        self.assertEqual(ldi.codename(), '')
-        self.assertEqual(ldi.base(), 'suse')
-
-    def test_fedora23_os_release(self):
-        os_release = os.path.join(DISTROS, 'fedora23', 'etc', 'os-release')
-
-        ldi = ld.LinuxDistribution(False, os_release, 'non')
-
-        self.assertEqual(ldi.id(), 'fedora')
-        self.assertEqual(ldi.name(), 'Fedora')
-        self.assertEqual(ldi.name(pretty=True), 'Fedora 23 (Twenty Three)')
-        self.assertEqual(ldi.version(), '23')
-        self.assertEqual(ldi.version(pretty=True), '23 (Twenty Three)')
+        self.assertEqual(ldi.id(), 'slackware')
+        self.assertEqual(ldi.name(), 'Slackware')
+        self.assertEqual(ldi.name(pretty=True), 'Slackware 14.1')
+        self.assertEqual(ldi.version(), '14.1')
+        self.assertEqual(ldi.version(pretty=True), '14.1')
         self.assertEqual(ldi.like(), '')
-        self.assertEqual(ldi.codename(), 'Twenty Three')
-        self.assertEqual(ldi.base(), 'fedora')
+        self.assertEqual(ldi.codename(), '')
+        self.assertEqual(ldi.base(), 'slackware')
 
     def test_ubuntu14_os_release(self):
         os_release = os.path.join(DISTROS, 'ubuntu14', 'etc', 'os-release')
@@ -92,62 +148,6 @@ class TestOSRelease(testtools.TestCase):
         self.assertEqual(ldi.like(), 'debian')
         self.assertEqual(ldi.codename(), 'Trusty Tahr')
         self.assertEqual(ldi.base(), 'debian')
-
-    def test_arch_os_release(self):
-        os_release = os.path.join(DISTROS, 'arch', 'etc', 'os-release')
-
-        ldi = ld.LinuxDistribution(False, os_release, 'non')
-
-        self.assertEqual(ldi.id(), 'arch')
-        self.assertEqual(ldi.name(), 'Arch Linux')
-        self.assertEqual(ldi.name(pretty=True), 'Arch Linux')
-        self.assertEqual(ldi.version(), '')
-        self.assertEqual(ldi.version(pretty=True), '')
-        self.assertEqual(ldi.like(), '')
-        self.assertEqual(ldi.codename(), '')
-        self.assertEqual(ldi.base(), 'arch')
-
-    def test_debian8_os_release(self):
-        os_release = os.path.join(DISTROS, 'debian8', 'etc', 'os-release')
-
-        ldi = ld.LinuxDistribution(False, os_release, 'non')
-
-        self.assertEqual(ldi.id(), 'debian')
-        self.assertEqual(ldi.name(), 'Debian GNU/Linux')
-        self.assertEqual(ldi.name(pretty=True), 'Debian GNU/Linux 8 (jessie)')
-        self.assertEqual(ldi.version(), '8')
-        self.assertEqual(ldi.version(pretty=True), '8 (jessie)')
-        self.assertEqual(ldi.like(), '')
-        self.assertEqual(ldi.codename(), 'jessie')
-        self.assertEqual(ldi.base(), 'debian')
-
-    def test_mageia5_os_release(self):
-        os_release = os.path.join(DISTROS, 'mageia5', 'etc', 'os-release')
-
-        ldi = ld.LinuxDistribution(False, os_release, 'non')
-
-        self.assertEqual(ldi.id(), 'mageia')
-        self.assertEqual(ldi.name(), 'Mageia')
-        self.assertEqual(ldi.name(pretty=True), 'Mageia 5')
-        self.assertEqual(ldi.version(), '5')
-        self.assertEqual(ldi.version(pretty=True), '5')
-        self.assertEqual(ldi.like(), 'mandriva fedora')
-        self.assertEqual(ldi.codename(), '')
-        self.assertEqual(ldi.base(), 'mandrake')
-
-    def test_slackware14_os_release(self):
-        os_release = os.path.join(DISTROS, 'slackware14', 'etc', 'os-release')
-
-        ldi = ld.LinuxDistribution(False, os_release, 'non')
-
-        self.assertEqual(ldi.id(), 'slackware')
-        self.assertEqual(ldi.name(), 'Slackware')
-        self.assertEqual(ldi.name(pretty=True), 'Slackware 14.1')
-        self.assertEqual(ldi.version(), '14.1')
-        self.assertEqual(ldi.version(pretty=True), '14.1')
-        self.assertEqual(ldi.like(), '')
-        self.assertEqual(ldi.codename(), '')
-        self.assertEqual(ldi.base(), 'slackware')
 
 
 class TestLSBRelease(testtools.TestCase):
@@ -210,61 +210,21 @@ class TestDistRelease(testtools.TestCase):
     def setUp(self):
         super(TestDistRelease, self).setUp()
 
-    def test_rhel7_release(self):
-        distro_release = os.path.join(DISTROS, 'rhel7', 'etc',
-                                      'redhat-release')
+    def test_arch_dist_release(self):
+        distro_release = os.path.join(DISTROS, 'arch', 'etc', 'arch-release')
 
         ldi = ld.LinuxDistribution(False, 'non', distro_release)
 
-        self.assertEqual(ldi.id(), 'redhat')
-        self.assertEqual(ldi.name(), 'Red Hat Enterprise Linux Server')
-        self.assertEqual(
-            ldi.name(pretty=True),
-            'Red Hat Enterprise Linux Server 7.0 (Maipo)')
-        self.assertEqual(ldi.version(), '7.0')
-        self.assertEqual(ldi.version(pretty=True), '7.0 (Maipo)')
+        self.assertEqual(ldi.id(), 'arch')
+        self.assertEqual(ldi.name(), '')
+        self.assertEqual(ldi.name(pretty=True), '')
+        self.assertEqual(ldi.version(), '')
+        self.assertEqual(ldi.version(pretty=True), '')
         self.assertEqual(ldi.like(), '')
-        self.assertEqual(ldi.codename(), 'Maipo')
-        self.assertEqual(ldi.base(), 'rhel')
-        self.assertEqual(ldi.version_parts(), ('7', '0', ''))
+        self.assertEqual(ldi.codename(), '')
+        self.assertEqual(ldi.base(), 'arch')
 
-    def test_rhel6_release(self):
-        distro_release = os.path.join(DISTROS, 'rhel6', 'etc',
-                                      'redhat-release')
-
-        ldi = ld.LinuxDistribution(False, 'non', distro_release)
-
-        self.assertEqual(ldi.id(), 'redhat')
-        self.assertEqual(ldi.name(), 'Red Hat Enterprise Linux Server')
-        self.assertEqual(
-            ldi.name(pretty=True),
-            'Red Hat Enterprise Linux Server 6.5 (Santiago)')
-        self.assertEqual(ldi.version(), '6.5')
-        self.assertEqual(ldi.version(pretty=True), '6.5 (Santiago)')
-        self.assertEqual(ldi.like(), '')
-        self.assertEqual(ldi.codename(), 'Santiago')
-        self.assertEqual(ldi.base(), 'rhel')
-        self.assertEqual(ldi.version_parts(), ('6', '5', ''))
-
-    def test_opensuse42_release(self):
-        distro_release = os.path.join(DISTROS, 'opensuse42', 'etc',
-                                      'SuSE-release')
-
-        ldi = ld.LinuxDistribution(False, 'non', distro_release)
-
-        self.assertEqual(ldi.id(), 'SuSE')
-        self.assertEqual(ldi.name(), 'openSUSE')
-        self.assertEqual(ldi.name(pretty=True), 'openSUSE 42.1 (x86_64)')
-        self.assertEqual(ldi.version(), '42.1')
-        self.assertEqual(ldi.version(pretty=True), '42.1 (x86_64)')
-        self.assertEqual(ldi.like(), '')
-        self.assertEqual(ldi.codename(), 'x86_64')
-        self.assertEqual(ldi.base(), 'suse')
-        self.assertEqual(ldi.major_version(), '42')
-        self.assertEqual(ldi.minor_version(), '1')
-        self.assertEqual(ldi.build_number(), '')
-
-    def test_centos5_release(self):
+    def test_centos5_dist_release(self):
         distro_release = os.path.join(DISTROS, 'centos5', 'etc',
                                       'centos-release')
         ldi = ld.LinuxDistribution(False, 'non', distro_release)
@@ -281,7 +241,7 @@ class TestDistRelease(testtools.TestCase):
         self.assertEqual(ldi.minor_version(), '11')
         self.assertEqual(ldi.build_number(), '')
 
-    def test_centos7_release(self):
+    def test_centos7_dist_release(self):
         distro_release = os.path.join(DISTROS, 'centos7', 'etc',
                                       'centos-release')
 
@@ -299,37 +259,7 @@ class TestDistRelease(testtools.TestCase):
         self.assertEqual(ldi.minor_version(), '1')
         self.assertEqual(ldi.build_number(), '1503')
 
-    def test_fedora23_release(self):
-        distro_release = os.path.join(DISTROS, 'fedora23', 'etc',
-                                      'fedora-release')
-
-        ldi = ld.LinuxDistribution(False, 'non', distro_release)
-
-        self.assertEqual(ldi.id(), 'fedora')
-        self.assertEqual(ldi.name(), 'Fedora')
-        self.assertEqual(ldi.name(pretty=True), 'Fedora 23 (Twenty Three)')
-        self.assertEqual(ldi.version(), '23')
-        self.assertEqual(ldi.version(pretty=True), '23 (Twenty Three)')
-        self.assertEqual(ldi.like(), '')
-        self.assertEqual(ldi.codename(), 'Twenty Three')
-        self.assertEqual(ldi.base(), 'fedora')
-
-    def test_oracle7_release(self):
-        distro_release = os.path.join(DISTROS, 'oracle7', 'etc',
-                                      'oracle-release')
-
-        ldi = ld.LinuxDistribution(False, 'non', distro_release)
-
-        self.assertEqual(ldi.id(), 'oracle')
-        self.assertEqual(ldi.name(), 'Oracle Linux Server')
-        self.assertEqual(ldi.name(pretty=True), 'Oracle Linux Server 7.1')
-        self.assertEqual(ldi.version(), '7.1')
-        self.assertEqual(ldi.version(pretty=True), '7.1')
-        self.assertEqual(ldi.like(), '')
-        self.assertEqual(ldi.codename(), '')
-        self.assertEqual(ldi.base(), 'rhel')
-
-    def test_empty_release(self):
+    def test_empty_dist_release(self):
         distro_release = os.path.join(SPECIAL, 'empty-release')
 
         ldi = ld.LinuxDistribution(False, 'non', distro_release)
@@ -343,21 +273,7 @@ class TestDistRelease(testtools.TestCase):
         self.assertEqual(ldi.codename(), '')
         self.assertEqual(ldi.base(), '')
 
-    def test_arch_release(self):
-        distro_release = os.path.join(DISTROS, 'arch', 'etc', 'arch-release')
-
-        ldi = ld.LinuxDistribution(False, 'non', distro_release)
-
-        self.assertEqual(ldi.id(), 'arch')
-        self.assertEqual(ldi.name(), '')
-        self.assertEqual(ldi.name(pretty=True), '')
-        self.assertEqual(ldi.version(), '')
-        self.assertEqual(ldi.version(pretty=True), '')
-        self.assertEqual(ldi.like(), '')
-        self.assertEqual(ldi.codename(), '')
-        self.assertEqual(ldi.base(), 'arch')
-
-    def test_exherbo_release(self):
+    def test_exherbo_dist_release(self):
         distro_release = os.path.join(DISTROS, 'exherbo', 'etc',
                                       'exherbo-release')
         # TODO: This release file is currently empty and should be completed.
@@ -373,7 +289,22 @@ class TestDistRelease(testtools.TestCase):
         self.assertEqual(ldi.codename(), '')
         self.assertEqual(ldi.base(), 'exherbo')
 
-    def test_mageia5_release(self):
+    def test_fedora23_dist_release(self):
+        distro_release = os.path.join(DISTROS, 'fedora23', 'etc',
+                                      'fedora-release')
+
+        ldi = ld.LinuxDistribution(False, 'non', distro_release)
+
+        self.assertEqual(ldi.id(), 'fedora')
+        self.assertEqual(ldi.name(), 'Fedora')
+        self.assertEqual(ldi.name(pretty=True), 'Fedora 23 (Twenty Three)')
+        self.assertEqual(ldi.version(), '23')
+        self.assertEqual(ldi.version(pretty=True), '23 (Twenty Three)')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), 'Twenty Three')
+        self.assertEqual(ldi.base(), 'fedora')
+
+    def test_mageia5_dist_release(self):
         distro_release = os.path.join(DISTROS, 'mageia5', 'etc',
                                       'mageia-release')
 
@@ -388,7 +319,76 @@ class TestDistRelease(testtools.TestCase):
         self.assertEqual(ldi.codename(), 'Official')
         self.assertEqual(ldi.base(), 'mandrake')
 
-    def test_slackware14_release(self):
+    def test_opensuse42_dist_release(self):
+        distro_release = os.path.join(DISTROS, 'opensuse42', 'etc',
+                                      'SuSE-release')
+
+        ldi = ld.LinuxDistribution(False, 'non', distro_release)
+
+        self.assertEqual(ldi.id(), 'SuSE')
+        self.assertEqual(ldi.name(), 'openSUSE')
+        self.assertEqual(ldi.name(pretty=True), 'openSUSE 42.1 (x86_64)')
+        self.assertEqual(ldi.version(), '42.1')
+        self.assertEqual(ldi.version(pretty=True), '42.1 (x86_64)')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), 'x86_64')
+        self.assertEqual(ldi.base(), 'suse')
+        self.assertEqual(ldi.major_version(), '42')
+        self.assertEqual(ldi.minor_version(), '1')
+        self.assertEqual(ldi.build_number(), '')
+
+    def test_oracle7_dist_release(self):
+        distro_release = os.path.join(DISTROS, 'oracle7', 'etc',
+                                      'oracle-release')
+
+        ldi = ld.LinuxDistribution(False, 'non', distro_release)
+
+        self.assertEqual(ldi.id(), 'oracle')
+        self.assertEqual(ldi.name(), 'Oracle Linux Server')
+        self.assertEqual(ldi.name(pretty=True), 'Oracle Linux Server 7.1')
+        self.assertEqual(ldi.version(), '7.1')
+        self.assertEqual(ldi.version(pretty=True), '7.1')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), '')
+        self.assertEqual(ldi.base(), 'rhel')
+
+    def test_rhel6_dist_release(self):
+        distro_release = os.path.join(DISTROS, 'rhel6', 'etc',
+                                      'redhat-release')
+
+        ldi = ld.LinuxDistribution(False, 'non', distro_release)
+
+        self.assertEqual(ldi.id(), 'redhat')
+        self.assertEqual(ldi.name(), 'Red Hat Enterprise Linux Server')
+        self.assertEqual(
+            ldi.name(pretty=True),
+            'Red Hat Enterprise Linux Server 6.5 (Santiago)')
+        self.assertEqual(ldi.version(), '6.5')
+        self.assertEqual(ldi.version(pretty=True), '6.5 (Santiago)')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), 'Santiago')
+        self.assertEqual(ldi.base(), 'rhel')
+        self.assertEqual(ldi.version_parts(), ('6', '5', ''))
+
+    def test_rhel7_dist_release(self):
+        distro_release = os.path.join(DISTROS, 'rhel7', 'etc',
+                                      'redhat-release')
+
+        ldi = ld.LinuxDistribution(False, 'non', distro_release)
+
+        self.assertEqual(ldi.id(), 'redhat')
+        self.assertEqual(ldi.name(), 'Red Hat Enterprise Linux Server')
+        self.assertEqual(
+            ldi.name(pretty=True),
+            'Red Hat Enterprise Linux Server 7.0 (Maipo)')
+        self.assertEqual(ldi.version(), '7.0')
+        self.assertEqual(ldi.version(pretty=True), '7.0 (Maipo)')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), 'Maipo')
+        self.assertEqual(ldi.base(), 'rhel')
+        self.assertEqual(ldi.version_parts(), ('7', '0', ''))
+
+    def test_slackware14_dist_release(self):
         distro_release = os.path.join(DISTROS, 'slackware14', 'etc',
                                       'slackware-version')
 
@@ -475,7 +475,7 @@ class TestOverall(testtools.TestCase):
         self.assertEqual(ldi.minor_version(), '')
         self.assertEqual(ldi.build_number(), '')
 
-    def test_debian8_os_release(self):
+    def test_debian8_release(self):
         self._setup_for_distro(os.path.join(DISTROS, 'debian8'))
 
         ldi = ld.LinuxDistribution()
@@ -614,7 +614,7 @@ class TestOverall(testtools.TestCase):
         self.assertEqual(ldi.codename(), '')
         self.assertEqual(ldi.base(), 'slackware')
 
-    def test_ubuntu14_os_release(self):
+    def test_ubuntu14_release(self):
         self._setup_for_distro(os.path.join(DISTROS, 'ubuntu14'))
 
         ldi = ld.LinuxDistribution()
@@ -628,7 +628,7 @@ class TestOverall(testtools.TestCase):
         self.assertEqual(ldi.codename(), 'Trusty Tahr')
         self.assertEqual(ldi.base(), 'debian')
 
-    def test_unknowndistro_os_release(self):
+    def test_unknowndistro_release(self):
         self._setup_for_distro(os.path.join(TESTDISTROS, 'unknowndistro'))
 
         ldi = ld.LinuxDistribution()


### PR DESCRIPTION
This PR contains fixes for issues #40 and #48, as proposed in the descriptions.

This includes some restructuring in the processing of distro release files.

Also, the distro release file dict now contains only those entries that were found (as opposed to all
entries with the empty string if no information was found). The users of accessor functions like `id()` or `get*attr()` see no change due to this, because they default non-existing entries to the empty string.

Finally, the distro ID found in the file name of the distro release file is no longer stored in `self.dist`, but as key 'id' in the distro release file dict. This seems to be more consistent, to me.

Note the change in expected test case results, when reviewing.