### PR TITLE
Query script hashbang

### DIFF
--- a/ld/__init__.py
+++ b/ld/__init__.py
@@ -609,7 +609,7 @@ class LinuxDistribution(object):
             version_parts=dict(
                 major=self.major_version(),
                 minor=self.minor_version(),
-                build_number=build_number()
+                build_number=self.build_number()
             ),
             like=self.like(),
         )

--- a/query_local_distro.py
+++ b/query_local_distro.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 import ld
 


### PR DESCRIPTION
PR #51 added a hashbang to the `query_local_distro.py` script, but did it incorrectly (and apparently without any testing ... :-(

This PR fixes the hashbang.

I verified that no other Python script contains an incorrect hashbang.