### PR TITLE
Fixes #64: Fixed missing or incorrect information in setup script + bumped version to 0.5.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,1 +1,66 @@
-For information on this package please refer to http://github.com/nir0s/ld
+The `ld` (linux distribution) package provides information about the
+Linux distribution it runs on, such as a reliable machine-readable ID, or
+version information.
+
+It is a renewed alternative implementation for Python's
+original `platform.linux_distribution` function, but it also provides much more
+functionality.
+An alternative implementation became necessary because Python 3.5 deprecated
+this function, and Python 3.7 is expected to remove it altogether.
+Its predecessor function `platform.dist` was already deprecated since
+Python 2.6 and is also expected to be removed in Python 3.7.
+Still, there are many cases in which access to that information is needed.
+See [Python issue 1322](https://bugs.python.org/issue1322) for more
+information.
+
+The `ld` package implements a robust and inclusive way of retrieving the
+information about a Linux distribution based on new standards and old methods,
+namely from these data sources (from high to low precedence):
+
+* The os-release file `/etc/os-release`, if present.
+* The output of the `lsb_release` command, if available.
+* The distro release file (`/etc/*(-|_)(release|version)`), if present.
+
+`ld` is tested on Python 2.6, 2.7 and 3.5.
+
+
+## Installation
+
+```shell
+pip install ld
+```
+
+For dev:
+
+```shell
+pip install https://github.com/nir0s/ld/archive/master.tar.gz
+```
+
+## Distribution Support
+
+The following distributions are tested (this is by no means an exhaustive list
+of supported distros as any distro adhering to the same standards should work):
+
+* Arch
+* CentOS 5/7
+* Debian 8
+* Exherbo
+* Fedora 23
+* Mageia 5
+* openSUSE Leap 42
+* Oracle Linux Server 7
+* RHEL 6/7
+* Slackware 14
+* Ubuntu 14
+
+## Usage
+
+```
+python
+>>> import ld
+>>> ld.linux_distribution(full_distribution_name=False)
+'('centos', '7.1.1503', 'Core')'
+```
+
+Several more functions are available. For a complete description of the
+API, see the [latest API documentation](http://ld.readthedocs.org/en/latest/).

--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,25 @@ def read(*parts):
 
 setup(
     name='ld',
-    version="0.2.9",
+    version="0.5.0",
     url='https://github.com/nir0s/ld',
-    author='nir0s',
+    author='Nir Cohen',
     author_email='nir36g@gmail.com',
-    license='LICENSE',
+    license='Apache License, Version 2.0',
     platforms='All',
     description='Linux OS Platform Information API',
     long_description=read('README.rst'),
-    packages=['ld']
+    packages=['ld'],
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Topic :: System :: Operating System',
+    ]
 )


### PR DESCRIPTION
Fixed the following issues in the setup.py script:

* Added the 'classifiers' argument.
* Changed the value of the 'license' argument from license file name to the actual license name.
* The 'long_description' argument is used by Pypi to build the Pypi home page. Changed it from the content of the README.rst file to the content of the README.md file (which is also shown on the Github project page).

Also, bumped version to 0.5.0.
