### PR TITLE
Added ibmkvm to set of reliable distros

### DIFF
--- a/ld/__init__.py
+++ b/ld/__init__.py
@@ -716,6 +716,7 @@ class LinuxDistribution(object):
         "exherbo"       Exherbo Linux
         "gentoo"        GenToo Linux
         "ibm_powerkvm"  IBM PowerKVM
+        "ibmkvm"        KVM for IBM z Systems
         "linuxmint"     Linux Mint
         "mageia"        Mageia
         "mandriva"      Mandriva Linux


### PR DESCRIPTION
This PR adds the distro "KVM for IBM z Systems" with the ID "ibmkvm" to the set of reliable distros. See https://www-03.ibm.com/systems/z/solutions/virtualization/kvm/ for details.