### PR TITLE
Fixes #59: Improved handling of lsb_release execution errors.

### DIFF
--- a/ld/__init__.py
+++ b/ld/__init__.py
@@ -548,7 +548,7 @@ class LinuxDistribution(object):
         elif rc == 127:  # Command not found
             return {}
         else:
-            if sys.version_info[0:2] >= (2,7):
+            if sys.version_info[0:2] >= (2, 7):
                 raise subprocess.CalledProcessError(rc, cmd, err)
             else:
                 raise subprocess.CalledProcessError(rc, cmd)

--- a/tests/resources/testdistros/lsb/lsb_rc001/bin/lsb_release
+++ b/tests/resources/testdistros/lsb/lsb_rc001/bin/lsb_release
@@ -1,0 +1,5 @@
+#!/bin/bash
+rc=1
+msg="General error"
+echo "Test failure - exiting with $rc ($msg)"
+exit $rc

--- a/tests/resources/testdistros/lsb/lsb_rc002/bin/lsb_release
+++ b/tests/resources/testdistros/lsb/lsb_rc002/bin/lsb_release
@@ -1,0 +1,5 @@
+#!/bin/bash
+rc=2
+msg="Misuse of shell builtins, or missing keyword or command"
+echo "Test failure - exiting with $rc ($msg)"
+exit $rc

--- a/tests/resources/testdistros/lsb/lsb_rc126/bin/lsb_release
+++ b/tests/resources/testdistros/lsb/lsb_rc126/bin/lsb_release
@@ -1,0 +1,5 @@
+#!/bin/bash
+rc=126
+msg="Cannot execute command"
+echo "Test failure - exiting with $rc ($msg)"
+exit $rc

--- a/tests/resources/testdistros/lsb/lsb_rc130/bin/lsb_release
+++ b/tests/resources/testdistros/lsb/lsb_rc130/bin/lsb_release
@@ -1,0 +1,5 @@
+#!/bin/bash
+rc=130
+msg="Signal 2 - Script terminated with Ctrl-C"
+echo "Test failure - exiting with $rc ($msg)"
+exit $rc

--- a/tests/resources/testdistros/lsb/lsb_rc255/bin/lsb_release
+++ b/tests/resources/testdistros/lsb/lsb_rc255/bin/lsb_release
@@ -1,0 +1,5 @@
+#!/bin/bash
+rc=255
+msg="Exit code out of range"
+echo "Test failure - exiting with $rc ($msg)"
+exit $rc

--- a/tests/test_ld.py
+++ b/tests/test_ld.py
@@ -3,7 +3,7 @@ try:
     from StringIO import StringIO  # Python 2.x
 except ImportError:
     from io import StringIO  # Python 3.x
-
+import subprocess
 import testtools
 
 import ld
@@ -182,8 +182,6 @@ class TestLSBRelease(DistroTestCase):
         self._setup_for_distro(os.path.join(TESTDISTROS, 'lsb',
                                             'ubuntu14_normal'))
 
-        #import pdb; pdb.set_trace()
-
         ldi = ld.LinuxDistribution(True, 'non', 'non')
 
         self.assertEqual(ldi.id(), 'ubuntu')
@@ -224,6 +222,56 @@ class TestLSBRelease(DistroTestCase):
         self.assertEqual(ldi.version(best=True), '14.04')
         self.assertEqual(ldi.like(), '')
         self.assertEqual(ldi.codename(), 'trusty')
+
+    def test_lsb_release_rc001(self):
+        self._setup_for_distro(os.path.join(TESTDISTROS, 'lsb', 'lsb_rc001'))
+        try:
+            ldi = ld.LinuxDistribution(True, 'non', 'non')
+            exc = None
+        except Exception as _exc:
+            exc = _exc
+        self.assertEqual(isinstance(exc, subprocess.CalledProcessError), True)
+        self.assertEqual(exc.returncode, 1)
+
+    def test_lsb_release_rc002(self):
+        self._setup_for_distro(os.path.join(TESTDISTROS, 'lsb', 'lsb_rc002'))
+        try:
+            ldi = ld.LinuxDistribution(True, 'non', 'non')
+            exc = None
+        except Exception as _exc:
+            exc = _exc
+        self.assertEqual(isinstance(exc, subprocess.CalledProcessError), True)
+        self.assertEqual(exc.returncode, 2)
+
+    def test_lsb_release_rc126(self):
+        self._setup_for_distro(os.path.join(TESTDISTROS, 'lsb', 'lsb_rc126'))
+        try:
+            ldi = ld.LinuxDistribution(True, 'non', 'non')
+            exc = None
+        except Exception as _exc:
+            exc = _exc
+        self.assertEqual(isinstance(exc, subprocess.CalledProcessError), True)
+        self.assertEqual(exc.returncode, 126)
+
+    def test_lsb_release_rc130(self):
+        self._setup_for_distro(os.path.join(TESTDISTROS, 'lsb', 'lsb_rc130'))
+        try:
+            ldi = ld.LinuxDistribution(True, 'non', 'non')
+            exc = None
+        except Exception as _exc:
+            exc = _exc
+        self.assertEqual(isinstance(exc, subprocess.CalledProcessError), True)
+        self.assertEqual(exc.returncode, 130)
+
+    def test_lsb_release_rc255(self):
+        self._setup_for_distro(os.path.join(TESTDISTROS, 'lsb', 'lsb_rc255'))
+        try:
+            ldi = ld.LinuxDistribution(True, 'non', 'non')
+            exc = None
+        except Exception as _exc:
+            exc = _exc
+        self.assertEqual(isinstance(exc, subprocess.CalledProcessError), True)
+        self.assertEqual(exc.returncode, 255)
 
 
 class TestDistRelease(testtools.TestCase):


### PR DESCRIPTION
This PR improves the implementation of `_get_lsb_release_info()` so that it raises `subprocess.CalledProcessError`, if the lsb_release command fails with a non-zero exit code other than 127 (command not found). Exit code 127 continues to be ignored, producing an empty data source for lsb_release.

Testcases have been added for lsb_release commands that fail with a few popular exit codes.