### PR TITLE
Fixes #70: Added testcase for Fedora 19, and some fixes.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     description='Linux OS Platform Information API',
     long_description=read('README.rst'),
     packages=['ld'],
+    install_requires=['six'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/tests/resources/distros/fedora19/etc/fedora-release
+++ b/tests/resources/distros/fedora19/etc/fedora-release
@@ -1,0 +1,1 @@
+Fedora release 19 (Schrödinger’s Cat)

--- a/tests/resources/distros/fedora19/etc/issue
+++ b/tests/resources/distros/fedora19/etc/issue
@@ -1,0 +1,3 @@
+Fedora release 19 (Schrödinger’s Cat)
+Kernel \r on an \m (\l)
+

--- a/tests/resources/distros/fedora19/etc/issue.net
+++ b/tests/resources/distros/fedora19/etc/issue.net
@@ -1,0 +1,2 @@
+Fedora release 19 (Schrödinger’s Cat)
+Kernel \r on an \m (\l)

--- a/tests/resources/distros/fedora19/etc/os-release
+++ b/tests/resources/distros/fedora19/etc/os-release
@@ -1,0 +1,7 @@
+NAME=Fedora
+VERSION="19 (Schrödinger’s Cat)"
+ID=fedora
+VERSION_ID=19
+PRETTY_NAME="Fedora 19 (Schrödinger’s Cat)"
+ANSI_COLOR="0;34"
+CPE_NAME="cpe:/o:fedoraproject:fedora:19"

--- a/tests/resources/distros/fedora19/etc/redhat-release
+++ b/tests/resources/distros/fedora19/etc/redhat-release
@@ -1,0 +1,1 @@
+fedora-release

--- a/tests/resources/distros/fedora19/etc/system-release
+++ b/tests/resources/distros/fedora19/etc/system-release
@@ -1,0 +1,1 @@
+fedora-release

--- a/tests/resources/distros/fedora19/etc/system-release-cpe
+++ b/tests/resources/distros/fedora19/etc/system-release-cpe
@@ -1,0 +1,1 @@
+cpe:/o:fedoraproject:fedora:19

--- a/tests/test_ld.py
+++ b/tests/test_ld.py
@@ -103,6 +103,20 @@ class TestOSRelease(testtools.TestCase):
         self.assertEqual(ldi.like(), '')
         self.assertEqual(ldi.codename(), 'jessie')
 
+    def test_fedora19_os_release(self):
+        os_release = os.path.join(DISTROS, 'fedora19', 'etc', 'os-release')
+
+        ldi = ld.LinuxDistribution(False, os_release, 'non')
+
+        self.assertEqual(ldi.id(), 'fedora')
+        self.assertEqual(ldi.name(), 'Fedora')
+        self.assertEqual(ldi.name(pretty=True), u'Fedora 19 (Schr\u00F6dinger\u2019s Cat)')
+        self.assertEqual(ldi.version(), '19')
+        self.assertEqual(ldi.version(pretty=True), u'19 (Schr\u00F6dinger\u2019s Cat)')
+        self.assertEqual(ldi.version(best=True), '19')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), u'Schr\u00F6dinger\u2019s Cat')
+
     def test_fedora23_os_release(self):
         os_release = os.path.join(DISTROS, 'fedora23', 'etc', 'os-release')
 
@@ -372,6 +386,21 @@ class TestDistRelease(testtools.TestCase):
         self.assertEqual(ldi.like(), '')
         self.assertEqual(ldi.codename(), '')
 
+    def test_fedora19_dist_release(self):
+        distro_release = os.path.join(DISTROS, 'fedora19', 'etc',
+                                      'fedora-release')
+
+        ldi = ld.LinuxDistribution(False, 'non', distro_release)
+
+        self.assertEqual(ldi.id(), 'fedora')
+        self.assertEqual(ldi.name(), 'Fedora')
+        self.assertEqual(ldi.name(pretty=True), u'Fedora 19 (Schr\u00F6dinger\u2019s Cat)')
+        self.assertEqual(ldi.version(), '19')
+        self.assertEqual(ldi.version(pretty=True), u'19 (Schr\u00F6dinger\u2019s Cat)')
+        self.assertEqual(ldi.version(best=True), '19')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), u'Schr\u00F6dinger\u2019s Cat')
+
     def test_fedora23_dist_release(self):
         distro_release = os.path.join(DISTROS, 'fedora23', 'etc',
                                       'fedora-release')
@@ -627,6 +656,29 @@ class TestOverall(DistroTestCase):
 
         # Test the info from the searched distro release file
         # TODO: Add tests for searched Exherbo distro release file
+
+    def test_fedora19_release(self):
+        self._setup_for_distro(os.path.join(DISTROS, 'fedora19'))
+
+        ldi = ld.LinuxDistribution()
+
+        self.assertEqual(ldi.id(), 'fedora')
+        self.assertEqual(ldi.name(), 'Fedora')
+        self.assertEqual(ldi.name(pretty=True), u'Fedora 19 (Schr\u00F6dinger\u2019s Cat)')
+        self.assertEqual(ldi.version(), '19')
+        self.assertEqual(ldi.version(pretty=True), u'19 (Schr\u00F6dinger\u2019s Cat)')
+        self.assertEqual(ldi.version(best=True), '19')
+        self.assertEqual(ldi.like(), '')
+        self.assertEqual(ldi.codename(), u'Schr\u00F6dinger\u2019s Cat')
+
+        # Test the info from the searched distro release file
+        self.assertEqual(os.path.basename(ldi.distro_release_file),
+                         'fedora-release')
+        distro_info = ldi.distro_release_info()
+        self.assertEqual(distro_info['id'], 'fedora')
+        self.assertEqual(distro_info['name'], 'Fedora')
+        self.assertEqual(distro_info['version_id'], '19')
+        self.assertEqual(distro_info['codename'], u'Schr\u00F6dinger\u2019s Cat')
 
     def test_fedora23_release(self):
         self._setup_for_distro(os.path.join(DISTROS, 'fedora23'))


### PR DESCRIPTION
This PR adds a distro testcase for Fedora 19. Fedora 19 has two Unicode characters (ö, and the single quote U+2019) in its distro codename (Schrödinger's Cat).

This revealed that there were still some issues related to Unicode processing. This PR fixes them. Changed the lsb_release command output to be expected in UTF-8, and adjusted the code. Changed conditional processing dependent on the Python version to use common code from the "six" module. This of course introduced a dependency on the "six" module, which was added to the setup script via an `install_requires` parameter. 

Unrelated to this, the incorrect statement that the VERSION attribute of the os-release file is used for the version was corrected to say that VERSION_ID is used (see `version()`).