### PR TITLE
Fixes #94, fixes #112: Improved and fixed info() function.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -463,10 +463,6 @@ If you want to participate, please comment on the referenced issues.
    and distro release file, vs. dropping them.
    Please comment on `issue #95 <https://github.com/nir0s/ld/issues/95>`_.
 
-.. [#todo3] Review whether :func:`ld.info` should use the first version or the
-   best version for its version related entries.
-   Please comment on `issue #94 <https://github.com/nir0s/ld/issues/94>`_.
-
 .. [#todo5] Provide input on distros with a reliable ID that do not yet have
    testcases:
 

--- a/ld.py
+++ b/ld.py
@@ -596,11 +596,11 @@ class LinuxDistribution(object):
     def __repr__(self):
         return \
             "LinuxDistribution(" \
-            "os_release_file={!r}, " \
-            "distro_release_file={!r}, " \
-            "_os_release_info={!r}, " \
-            "_lsb_release_info={!r}, " \
-            "_distro_release_info={!r})".format(
+            "os_release_file={0!r}, " \
+            "distro_release_file={1!r}, " \
+            "_os_release_info={2!r}, " \
+            "_lsb_release_info={3!r}, " \
+            "_distro_release_info={4!r})".format(
                 self.os_release_file,
                 self.distro_release_file,
                 self._os_release_info,

--- a/ld.py
+++ b/ld.py
@@ -375,7 +375,7 @@ def codename():
     return _ldi.codename()
 
 
-def info(best=False):
+def info(pretty=False, best=False):
     """
     Return certain machine-readable information items about the current Linux
     distribution in a dictionary, as shown in the following example:
@@ -413,10 +413,10 @@ def info(best=False):
 
     * ``codename``:  The result of :func:`ld.codename`.
 
-    For a description of the *best* parameter, see the :func:`ld.version`
-    method.
+    For a description of the *pretty* and *best* parameters, see the
+    :func:`ld.version` method.
     """
-    return _ldi.info(best)
+    return _ldi.info(pretty, best)
 
 
 def os_release_info():
@@ -596,16 +596,16 @@ class LinuxDistribution(object):
     def __repr__(self):
         return \
             "LinuxDistribution(" \
-            "os_release_file=%r, " \
-            "distro_release_file=%r, " \
-            "_os_release_info=%r, " \
-            "_lsb_release_info=%r, " \
-            "_distro_release_info=%r)" % \
-            (self.os_release_file,
-             self.distro_release_file,
-             self._os_release_info,
-             self._lsb_release_info,
-             self._distro_release_info)
+            "os_release_file={!r}, " \
+            "distro_release_file={!r}, " \
+            "_os_release_info={!r}, " \
+            "_lsb_release_info={!r}, " \
+            "_distro_release_info={!r})".format(
+                self.os_release_file,
+                self.distro_release_file,
+                self._os_release_info,
+                self._lsb_release_info,
+                self._distro_release_info)
 
     def linux_distribution(self, full_distribution_name=True):
         """
@@ -755,7 +755,7 @@ class LinuxDistribution(object):
             or self.distro_release_attr('codename') \
             or ''
 
-    def info(self, best=False):
+    def info(self, pretty=False, best=False):
         """
         Return certain machine-readable information about the Linux
         distribution.
@@ -764,7 +764,7 @@ class LinuxDistribution(object):
         """
         return dict(
             id=self.id(),
-            version=self.version(best=best),
+            version=self.version(pretty, best),
             version_parts=dict(
                 major=self.major_version(best),
                 minor=self.minor_version(best),

--- a/ld.py
+++ b/ld.py
@@ -375,7 +375,7 @@ def codename():
     return _ldi.codename()
 
 
-def info():
+def info(best=False):
     """
     Return certain machine-readable information items about the current Linux
     distribution in a dictionary, as shown in the following example:
@@ -402,19 +402,21 @@ def info():
 
     * ``version``:  The result of :func:`ld.version`.
 
-    * ``major``:  The result of :func:`ld.major_version`.
+    * ``version_parts -> major``:  The result of :func:`ld.major_version`.
 
-    * ``minor``:  The result of :func:`ld.minor_version`.
+    * ``version_parts -> minor``:  The result of :func:`ld.minor_version`.
 
-    * ``build_number``:  The result of :func:`ld.build_number`.
+    * ``version_parts -> build_number``:  The result of
+      :func:`ld.build_number`.
 
     * ``like``:  The result of :func:`ld.like`.
 
     * ``codename``:  The result of :func:`ld.codename`.
 
-    .. todo:: See [#todo3]_ on using the first or best version for this dict.
+    For a description of the *best* parameter, see the :func:`ld.version`
+    method.
     """
-    return _ldi.info()
+    return _ldi.info(best)
 
 
 def os_release_info():
@@ -716,7 +718,7 @@ class LinuxDistribution(object):
 
         For details, see :func:`ld.major_version`.
         """
-        return self.version_parts(best=best)[0]
+        return self.version_parts(best)[0]
 
     def minor_version(self, best=False):
         """
@@ -724,7 +726,7 @@ class LinuxDistribution(object):
 
         For details, see :func:`ld.minor_version`.
         """
-        return self.version_parts(best=best)[1]
+        return self.version_parts(best)[1]
 
     def build_number(self, best=False):
         """
@@ -732,7 +734,7 @@ class LinuxDistribution(object):
 
         For details, see :func:`ld.build_number`.
         """
-        return self.version_parts(best=best)[2]
+        return self.version_parts(best)[2]
 
     def like(self):
         """
@@ -753,7 +755,7 @@ class LinuxDistribution(object):
             or self.distro_release_attr('codename') \
             or ''
 
-    def info(self):
+    def info(self, best=False):
         """
         Return certain machine-readable information about the Linux
         distribution.
@@ -762,13 +764,14 @@ class LinuxDistribution(object):
         """
         return dict(
             id=self.id(),
-            version=self.version(),
+            version=self.version(best=best),
             version_parts=dict(
-                major=self.major_version(),
-                minor=self.minor_version(),
-                build_number=self.build_number()
+                major=self.major_version(best),
+                minor=self.minor_version(best),
+                build_number=self.build_number(best)
             ),
             like=self.like(),
+            codename=self.codename(),
         )
 
     def os_release_info(self):

--- a/tests/test_ld.py
+++ b/tests/test_ld.py
@@ -1046,7 +1046,7 @@ class TestGetAttr(DistroTestCase):
             for key in info.keys():
                 self.assertEqual(info[key],
                                  ldi.os_release_attr(key),
-                                 "distro: %s, key: %s" % (distro, key))
+                                 "distro: {}, key: {}".format(distro, key))
 
     def test_lsb_release_attr(self):
         distros = os.listdir(DISTROS)
@@ -1059,7 +1059,7 @@ class TestGetAttr(DistroTestCase):
             for key in info.keys():
                 self.assertEqual(info[key],
                                  ldi.lsb_release_attr(key),
-                                 "distro: %s, key: %s" % (distro, key))
+                                 "distro: {}, key: {}".format(distro, key))
 
     def test_distro_release_attr(self):
         distros = os.listdir(DISTROS)
@@ -1072,7 +1072,7 @@ class TestGetAttr(DistroTestCase):
             for key in info.keys():
                 self.assertEqual(info[key],
                                  ldi.distro_release_attr(key),
-                                 "distro: %s, key: %s" % (distro, key))
+                                 "distro: {}, key: {}".format(distro, key))
 
 
 class TestInfo(DistroTestCase):
@@ -1092,6 +1092,7 @@ class TestInfo(DistroTestCase):
         self.assertEqual(info['version_parts']['major'], '7')
         self.assertEqual(info['version_parts']['minor'], '0')
         self.assertEqual(info['version_parts']['build_number'], '')
+        self.assertEqual(info['codename'], 'Maipo')
 
         info = ldi.info(best=True)
         self.assertEqual(info['id'], 'rhel')
@@ -1100,6 +1101,25 @@ class TestInfo(DistroTestCase):
         self.assertEqual(info['version_parts']['major'], '7')
         self.assertEqual(info['version_parts']['minor'], '0')
         self.assertEqual(info['version_parts']['build_number'], '')
+        self.assertEqual(info['codename'], 'Maipo')
+
+        info = ldi.info(pretty=True)
+        self.assertEqual(info['id'], 'rhel')
+        self.assertEqual(info['version'], '7.0 (Maipo)')
+        self.assertEqual(info['like'], 'fedora')
+        self.assertEqual(info['version_parts']['major'], '7')
+        self.assertEqual(info['version_parts']['minor'], '0')
+        self.assertEqual(info['version_parts']['build_number'], '')
+        self.assertEqual(info['codename'], 'Maipo')
+
+        info = ldi.info(pretty=True, best=True)
+        self.assertEqual(info['id'], 'rhel')
+        self.assertEqual(info['version'], '7.0 (Maipo)')
+        self.assertEqual(info['like'], 'fedora')
+        self.assertEqual(info['version_parts']['major'], '7')
+        self.assertEqual(info['version_parts']['minor'], '0')
+        self.assertEqual(info['version_parts']['build_number'], '')
+        self.assertEqual(info['codename'], 'Maipo')
 
     def test_none(self):
         ldi = ld.LinuxDistribution(False, 'non', 'non')
@@ -1111,6 +1131,7 @@ class TestInfo(DistroTestCase):
         self.assertEqual(info['version_parts']['major'], '')
         self.assertEqual(info['version_parts']['minor'], '')
         self.assertEqual(info['version_parts']['build_number'], '')
+        self.assertEqual(info['codename'], '')
 
         info = ldi.info(best=True)
         self.assertEqual(info['id'], '')
@@ -1119,6 +1140,25 @@ class TestInfo(DistroTestCase):
         self.assertEqual(info['version_parts']['major'], '')
         self.assertEqual(info['version_parts']['minor'], '')
         self.assertEqual(info['version_parts']['build_number'], '')
+        self.assertEqual(info['codename'], '')
+
+        info = ldi.info(pretty=True)
+        self.assertEqual(info['id'], '')
+        self.assertEqual(info['version'], '')
+        self.assertEqual(info['like'], '')
+        self.assertEqual(info['version_parts']['major'], '')
+        self.assertEqual(info['version_parts']['minor'], '')
+        self.assertEqual(info['version_parts']['build_number'], '')
+        self.assertEqual(info['codename'], '')
+
+        info = ldi.info(pretty=True, best=True)
+        self.assertEqual(info['id'], '')
+        self.assertEqual(info['version'], '')
+        self.assertEqual(info['like'], '')
+        self.assertEqual(info['version_parts']['major'], '')
+        self.assertEqual(info['version_parts']['minor'], '')
+        self.assertEqual(info['version_parts']['build_number'], '')
+        self.assertEqual(info['codename'], '')
 
     def test_linux_disribution(self):
         ldi = ld.LinuxDistribution(False, self.rhel7_os_release)
@@ -1144,57 +1184,113 @@ class TestInfo(DistroTestCase):
 
             self.assertEqual(info['id'],
                              ldi.id(),
-                             "distro: %s" % distro)
+                             "distro: {}".format(distro))
             self.assertEqual(info['version'],
                              ldi.version(),
-                             "distro: %s" % distro)
+                             "distro: {}".format(distro))
             self.assertEqual(info['version_parts']['major'],
                              ldi.major_version(),
-                             "distro: %s" % distro)
+                             "distro: {}".format(distro))
             self.assertEqual(info['version_parts']['minor'],
                              ldi.minor_version(),
-                             "distro: %s" % distro)
+                             "distro: {}".format(distro))
             self.assertEqual(info['version_parts']['build_number'],
                              ldi.build_number(),
-                             "distro: %s" % distro)
+                             "distro: {}".format(distro))
             self.assertEqual(info['like'],
                              ldi.like(),
-                             "distro: %s" % distro)
+                             "distro: {}".format(distro))
             self.assertEqual(info['codename'],
                              ldi.codename(),
-                             "distro: %s" % distro)
+                             "distro: {}".format(distro))
             self.assertEqual(len(info['version_parts']), 3,
-                             "distro: %s" % distro)
+                             "distro: {}".format(distro))
             self.assertEqual(len(info), 5,
-                             "distro: %s" % distro)
+                             "distro: {}".format(distro))
 
             info = ldi.info(best=True)
 
             self.assertEqual(info['id'],
                              ldi.id(),
-                             "distro: %s" % distro)
+                             "distro: {}".format(distro))
             self.assertEqual(info['version'],
                              ldi.version(best=True),
-                             "distro: %s" % distro)
+                             "distro: {}".format(distro))
             self.assertEqual(info['version_parts']['major'],
                              ldi.major_version(best=True),
-                             "distro: %s" % distro)
+                             "distro: {}".format(distro))
             self.assertEqual(info['version_parts']['minor'],
                              ldi.minor_version(best=True),
-                             "distro: %s" % distro)
+                             "distro: {}".format(distro))
             self.assertEqual(info['version_parts']['build_number'],
                              ldi.build_number(best=True),
-                             "distro: %s" % distro)
+                             "distro: {}".format(distro))
             self.assertEqual(info['like'],
                              ldi.like(),
-                             "distro: %s" % distro)
+                             "distro: {}".format(distro))
             self.assertEqual(info['codename'],
                              ldi.codename(),
-                             "distro: %s" % distro)
+                             "distro: {}".format(distro))
             self.assertEqual(len(info['version_parts']), 3,
-                             "distro: %s" % distro)
+                             "distro: {}".format(distro))
             self.assertEqual(len(info), 5,
-                             "distro: %s" % distro)
+                             "distro: {}".format(distro))
+
+            info = ldi.info(pretty=True)
+
+            self.assertEqual(info['id'],
+                             ldi.id(),
+                             "distro: {}".format(distro))
+            self.assertEqual(info['version'],
+                             ldi.version(pretty=True),
+                             "distro: {}".format(distro))
+            self.assertEqual(info['version_parts']['major'],
+                             ldi.major_version(),
+                             "distro: {}".format(distro))
+            self.assertEqual(info['version_parts']['minor'],
+                             ldi.minor_version(),
+                             "distro: {}".format(distro))
+            self.assertEqual(info['version_parts']['build_number'],
+                             ldi.build_number(),
+                             "distro: {}".format(distro))
+            self.assertEqual(info['like'],
+                             ldi.like(),
+                             "distro: {}".format(distro))
+            self.assertEqual(info['codename'],
+                             ldi.codename(),
+                             "distro: {}".format(distro))
+            self.assertEqual(len(info['version_parts']), 3,
+                             "distro: {}".format(distro))
+            self.assertEqual(len(info), 5,
+                             "distro: {}".format(distro))
+
+            info = ldi.info(pretty=True, best=True)
+
+            self.assertEqual(info['id'],
+                             ldi.id(),
+                             "distro: {}".format(distro))
+            self.assertEqual(info['version'],
+                             ldi.version(pretty=True, best=True),
+                             "distro: {}".format(distro))
+            self.assertEqual(info['version_parts']['major'],
+                             ldi.major_version(best=True),
+                             "distro: {}".format(distro))
+            self.assertEqual(info['version_parts']['minor'],
+                             ldi.minor_version(best=True),
+                             "distro: {}".format(distro))
+            self.assertEqual(info['version_parts']['build_number'],
+                             ldi.build_number(best=True),
+                             "distro: {}".format(distro))
+            self.assertEqual(info['like'],
+                             ldi.like(),
+                             "distro: {}".format(distro))
+            self.assertEqual(info['codename'],
+                             ldi.codename(),
+                             "distro: {}".format(distro))
+            self.assertEqual(len(info['version_parts']), 3,
+                             "distro: {}".format(distro))
+            self.assertEqual(len(info), 5,
+                             "distro: {}".format(distro))
 
 
 class TestOSReleaseParsing(testtools.TestCase):
@@ -1516,6 +1612,12 @@ class TestGlobal(testtools.TestCase):
             MODULE_LDI.info())
         self.assertEqual(ld.info(best=True),
             MODULE_LDI.info(best=True))
+        self.assertEqual(ld.info(),
+            MODULE_LDI.info(pretty=False))
+        self.assertEqual(ld.info(pretty=False),
+            MODULE_LDI.info())
+        self.assertEqual(ld.info(pretty=True),
+            MODULE_LDI.info(pretty=True))
 
         self.assertEqual(ld.os_release_info(),
             MODULE_LDI.os_release_info())

--- a/tests/test_ld.py
+++ b/tests/test_ld.py
@@ -1075,7 +1075,7 @@ class TestGetAttr(DistroTestCase):
                                  "distro: %s, key: %s" % (distro, key))
 
 
-class TestInfo(testtools.TestCase):
+class TestInfo(DistroTestCase):
 
     def setUp(self):
         super(TestInfo, self).setUp()
@@ -1086,6 +1086,14 @@ class TestInfo(testtools.TestCase):
         ldi = ld.LinuxDistribution(False, self.rhel7_os_release, 'non')
 
         info = ldi.info()
+        self.assertEqual(info['id'], 'rhel')
+        self.assertEqual(info['version'], '7.0')
+        self.assertEqual(info['like'], 'fedora')
+        self.assertEqual(info['version_parts']['major'], '7')
+        self.assertEqual(info['version_parts']['minor'], '0')
+        self.assertEqual(info['version_parts']['build_number'], '')
+
+        info = ldi.info(best=True)
         self.assertEqual(info['id'], 'rhel')
         self.assertEqual(info['version'], '7.0')
         self.assertEqual(info['like'], 'fedora')
@@ -1104,6 +1112,14 @@ class TestInfo(testtools.TestCase):
         self.assertEqual(info['version_parts']['minor'], '')
         self.assertEqual(info['version_parts']['build_number'], '')
 
+        info = ldi.info(best=True)
+        self.assertEqual(info['id'], '')
+        self.assertEqual(info['version'], '')
+        self.assertEqual(info['like'], '')
+        self.assertEqual(info['version_parts']['major'], '')
+        self.assertEqual(info['version_parts']['minor'], '')
+        self.assertEqual(info['version_parts']['build_number'], '')
+
     def test_linux_disribution(self):
         ldi = ld.LinuxDistribution(False, self.rhel7_os_release)
         i = ldi.linux_distribution()
@@ -1114,6 +1130,71 @@ class TestInfo(testtools.TestCase):
         ldi = ld.LinuxDistribution(False, self.rhel7_os_release)
         i = ldi.linux_distribution(full_distribution_name=False)
         self.assertEqual(i, ('rhel', '7.0', 'Maipo'))
+
+    def test_all(self):
+        """Test info() by comparing its results with the results of specific
+        consolidated accessor functions."""
+        distros = os.listdir(DISTROS)
+        for distro in distros:
+            self._setup_for_distro(os.path.join(DISTROS, distro))
+
+            ldi = ld.LinuxDistribution()
+
+            info = ldi.info()
+
+            self.assertEqual(info['id'],
+                             ldi.id(),
+                             "distro: %s" % distro)
+            self.assertEqual(info['version'],
+                             ldi.version(),
+                             "distro: %s" % distro)
+            self.assertEqual(info['version_parts']['major'],
+                             ldi.major_version(),
+                             "distro: %s" % distro)
+            self.assertEqual(info['version_parts']['minor'],
+                             ldi.minor_version(),
+                             "distro: %s" % distro)
+            self.assertEqual(info['version_parts']['build_number'],
+                             ldi.build_number(),
+                             "distro: %s" % distro)
+            self.assertEqual(info['like'],
+                             ldi.like(),
+                             "distro: %s" % distro)
+            self.assertEqual(info['codename'],
+                             ldi.codename(),
+                             "distro: %s" % distro)
+            self.assertEqual(len(info['version_parts']), 3,
+                             "distro: %s" % distro)
+            self.assertEqual(len(info), 5,
+                             "distro: %s" % distro)
+
+            info = ldi.info(best=True)
+
+            self.assertEqual(info['id'],
+                             ldi.id(),
+                             "distro: %s" % distro)
+            self.assertEqual(info['version'],
+                             ldi.version(best=True),
+                             "distro: %s" % distro)
+            self.assertEqual(info['version_parts']['major'],
+                             ldi.major_version(best=True),
+                             "distro: %s" % distro)
+            self.assertEqual(info['version_parts']['minor'],
+                             ldi.minor_version(best=True),
+                             "distro: %s" % distro)
+            self.assertEqual(info['version_parts']['build_number'],
+                             ldi.build_number(best=True),
+                             "distro: %s" % distro)
+            self.assertEqual(info['like'],
+                             ldi.like(),
+                             "distro: %s" % distro)
+            self.assertEqual(info['codename'],
+                             ldi.codename(),
+                             "distro: %s" % distro)
+            self.assertEqual(len(info['version_parts']), 3,
+                             "distro: %s" % distro)
+            self.assertEqual(len(info), 5,
+                             "distro: %s" % distro)
 
 
 class TestOSReleaseParsing(testtools.TestCase):
@@ -1430,7 +1511,11 @@ class TestGlobal(testtools.TestCase):
             MODULE_LDI.codename())
 
         self.assertEqual(ld.info(),
+            MODULE_LDI.info(best=False))
+        self.assertEqual(ld.info(best=False),
             MODULE_LDI.info())
+        self.assertEqual(ld.info(best=True),
+            MODULE_LDI.info(best=True))
 
         self.assertEqual(ld.os_release_info(),
             MODULE_LDI.os_release_info())

--- a/tests/test_ld.py
+++ b/tests/test_ld.py
@@ -1046,7 +1046,7 @@ class TestGetAttr(DistroTestCase):
             for key in info.keys():
                 self.assertEqual(info[key],
                                  ldi.os_release_attr(key),
-                                 "distro: {}, key: {}".format(distro, key))
+                                 "distro: {0}, key: {1}".format(distro, key))
 
     def test_lsb_release_attr(self):
         distros = os.listdir(DISTROS)
@@ -1059,7 +1059,7 @@ class TestGetAttr(DistroTestCase):
             for key in info.keys():
                 self.assertEqual(info[key],
                                  ldi.lsb_release_attr(key),
-                                 "distro: {}, key: {}".format(distro, key))
+                                 "distro: {0}, key: {1}".format(distro, key))
 
     def test_distro_release_attr(self):
         distros = os.listdir(DISTROS)
@@ -1072,7 +1072,7 @@ class TestGetAttr(DistroTestCase):
             for key in info.keys():
                 self.assertEqual(info[key],
                                  ldi.distro_release_attr(key),
-                                 "distro: {}, key: {}".format(distro, key))
+                                 "distro: {0}, key: {1}".format(distro, key))
 
 
 class TestInfo(DistroTestCase):
@@ -1184,113 +1184,113 @@ class TestInfo(DistroTestCase):
 
             self.assertEqual(info['id'],
                              ldi.id(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['version'],
                              ldi.version(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['version_parts']['major'],
                              ldi.major_version(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['version_parts']['minor'],
                              ldi.minor_version(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['version_parts']['build_number'],
                              ldi.build_number(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['like'],
                              ldi.like(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['codename'],
                              ldi.codename(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(len(info['version_parts']), 3,
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(len(info), 5,
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
 
             info = ldi.info(best=True)
 
             self.assertEqual(info['id'],
                              ldi.id(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['version'],
                              ldi.version(best=True),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['version_parts']['major'],
                              ldi.major_version(best=True),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['version_parts']['minor'],
                              ldi.minor_version(best=True),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['version_parts']['build_number'],
                              ldi.build_number(best=True),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['like'],
                              ldi.like(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['codename'],
                              ldi.codename(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(len(info['version_parts']), 3,
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(len(info), 5,
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
 
             info = ldi.info(pretty=True)
 
             self.assertEqual(info['id'],
                              ldi.id(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['version'],
                              ldi.version(pretty=True),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['version_parts']['major'],
                              ldi.major_version(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['version_parts']['minor'],
                              ldi.minor_version(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['version_parts']['build_number'],
                              ldi.build_number(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['like'],
                              ldi.like(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['codename'],
                              ldi.codename(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(len(info['version_parts']), 3,
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(len(info), 5,
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
 
             info = ldi.info(pretty=True, best=True)
 
             self.assertEqual(info['id'],
                              ldi.id(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['version'],
                              ldi.version(pretty=True, best=True),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['version_parts']['major'],
                              ldi.major_version(best=True),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['version_parts']['minor'],
                              ldi.minor_version(best=True),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['version_parts']['build_number'],
                              ldi.build_number(best=True),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['like'],
                              ldi.like(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(info['codename'],
                              ldi.codename(),
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(len(info['version_parts']), 3,
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
             self.assertEqual(len(info), 5,
-                             "distro: {}".format(distro))
+                             "distro: {0}".format(distro))
 
 
 class TestOSReleaseParsing(testtools.TestCase):


### PR DESCRIPTION
Ready to be merged.
Please review.

Details from the commit log:

- Added a `best` parameter to `info()`.
- Fixed implementation of `info()` by adding the missing `'codename'` item in its result.
- Improved test cases for `info()` by adding a generic all-distro test that compares the result of `info()` with the result of the specific consolidated accessor functions.
- Minor editorial improvements in documentation of `info()`.
- Removed todo3 about issue #94.