### PR TITLE
Fixes #62: Documented that codename() returns string as-is.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -467,11 +467,6 @@ If you want to participate, please comment on the referenced issues.
    best version for its version related entries.
    Please comment on `issue #94 <https://github.com/nir0s/ld/issues/94>`_.
 
-.. [#todo4] Provide your view as to whether something should be done about
-   non-codename strings in codename fields (e.g. "x86_64" in the codename field
-   for openSUSE), vs. just using it unchanged as the current code does.
-   Please comment on `issue #62 <https://github.com/nir0s/ld/issues/62>`_.
-
 .. [#todo5] Provide input on distros with a reliable ID that do not yet have
    testcases:
 

--- a/ld.py
+++ b/ld.py
@@ -359,9 +359,8 @@ def codename():
     If the distribution does not have a codename, an empty string is returned.
 
     Note that the returned codename is not always really a codename. For
-    example, openSUSE returns "x86_64".
-
-    .. todo:: See [#todo4]_ on whether something should be done about that.
+    example, openSUSE returns "x86_64". This function does not handle such
+    cases in any special way and just returns the string it finds, if any.
 
     **Lookup hierarchy:**
 


### PR DESCRIPTION
Ready to be merged.
Please review.

See issue #62 for details.